### PR TITLE
feat(openclaw): SSE streaming, temperature control, and token metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,190 +1,154 @@
 # MeshMind
 
-**A Privacy-First, Peer-to-Peer Local AI Network**
-
-> All AI inference runs on each user's own machine.
-> The cloud layer handles accounts, groups, and message routing only.
-> No prompt or response content ever touches the central server.
+A privacy-first local AI network with a **prompt marketplace** — ask AI on your own hardware, but skip redundant inference when someone else has already answered your question.
 
 ---
 
-## What Is MeshMind?
+## The Idea
 
-MeshMind is a web-based chat application where AI runs entirely on your own hardware. Unlike ChatGPT or Claude, your conversations never leave your machine. You can also form private groups with friends or teammates and optionally route a query to a peer with a more powerful local model — all end-to-end encrypted before it hits the relay.
+Running LLMs locally is cheap but slow and repetitive — thousands of people ask "how do JWT refresh tokens work?" and their GPU generates the same answer every time.
 
-The cloud is intentionally minimal: it stores user accounts, group memberships, and acts as an encrypted message relay. The AI itself runs locally via [Ollama](https://ollama.com), a free open-source tool for running LLMs on consumer hardware.
+MeshMind adds a shared, opt-in cache:
+
+1. You ask a question. Your local node **embeds it privately** (nothing leaves your machine yet).
+2. The cloud returns semantically similar prompts others have published.
+3. One of three things happens:
+   - **Verbatim hit** (similarity ≥ 0.90) — serve the cached answer, 0 inference tokens.
+   - **Repackage** (0.70–0.90) — your local model rewrites the cached answer to fit your exact question. ~10x fewer tokens than a fresh answer.
+   - **Miss** (< 0.70) — full local inference, and you can publish the result to earn credits.
+4. Authors earn credits every time their published answer gets consumed.
+
+Plaintext never leaves your machine unless **you** explicitly publish.
 
 ---
 
-## Architecture Overview
+## Architecture
 
 ```
-                        Cloud (AWS / GCP)
-                       ┌─────────────────────────────────┐
-                       │  WebSocket Relay                │
-                       │        │                        │
-                       │  Spring Boot API ──► PostgreSQL │
-                       └────────┬──────────┬────────────┘
-                     auth/groups│          │auth/groups
-                                │          │
-              ┌─────────────────┘          └───────────────────┐
-              │                                                 │
-     ┌────────▼────────┐   peer query (encrypted)   ┌─────────▼────────┐
-     │  React UI (A)   │ ◄────────────────────────► │  React UI (B)    │
-     └────────┬────────┘                             └────────┬─────────┘
-              │                                               │
-     ┌────────▼────────┐                             ┌────────▼─────────┐
-     │  Ollama (local) │                             │  Ollama (local)  │
-     └────────┬────────┘                             └────────┬─────────┘
-              │                                               │
-     ┌────────▼────────┐                             ┌────────▼─────────┐
-     │ SQLite (cache)  │                             │ SQLite (cache)   │
-     └─────────────────┘                             └──────────────────┘
-          Machine A                                       Machine B
+┌─ LOCAL (your machine) ───────────────────────────────┐
+│  OpenClaw (FastAPI, :8000)                           │
+│   ├── Ollama client (embed + chat)                   │
+│   ├── Market client (auth + search + publish)        │
+│   └── /api/ask orchestrator                          │
+│  Ollama (:11434) — nomic-embed-text + chat model     │
+└──────────────────────────────────────────────────────┘
+          │  (JWT; embeddings for search; plaintext only on publish)
+          ▼
+┌─ CLOUD (AWS/GCP) ────────────────────────────────────┐
+│  Spring Boot (:8080) — auth, marketplace, credits    │
+│  PostgreSQL 16 + pgvector — IVFFlat cosine index     │
+└──────────────────────────────────────────────────────┘
 ```
 
-The relay server passes encrypted blobs between peers. It cannot read message content.
+---
+
+## Quick Start
+
+```bash
+# 0. prerequisites: Docker, Python 3.10+, Ollama
+ollama pull nomic-embed-text
+ollama pull llama3.2
+
+# 1. bring up cloud stack
+docker-compose up -d
+
+# 2. run local node
+cd openclaw
+pip install -r requirements.txt
+uvicorn app.server:app --reload --port 8000
+
+# 3. open http://localhost:8000
+```
 
 ---
 
-## Technology Stack
+## Tech Stack
 
-| Layer | Technology | Role |
-|---|---|---|
-| Frontend | React + TypeScript | Chat UI, group sidebar, node dashboard |
-| Local inference | Ollama (REST API) | LLM backend on user's machine |
-| Local cache | SQLite | Offline conversation history |
-| Service layer | Spring Boot 3.x (Java 21) | Auth, node registry, groups, WebSocket relay |
-| Cloud database | PostgreSQL 16 | Users, groups, conversations |
-| Auth | Spring Security + JWT | Stateless API authentication |
-| Containers | Docker + docker-compose | Local dev and cloud deployment |
-| Cloud hosting | AWS EC2 + RDS or GCP Cloud Run + Cloud SQL | Production |
+| Layer | Tech |
+|---|---|
+| Local inference | Ollama (chat + `nomic-embed-text`) |
+| Local node | Python + FastAPI |
+| Cloud API | Spring Boot 3.x, Java 21 |
+| Vector search | PostgreSQL 16 + pgvector (IVFFlat, cosine) |
+| Auth | JWT + BCrypt |
+| Container | Docker, docker-compose |
 
 ---
 
-## Core Features
+## Repository Layout
 
-| ID | Feature | Status |
+```
+meshmind-v2/
+├── backend/            # Spring Boot cloud service (Schertz)
+│   ├── src/main/java/dev/meshmind/
+│   │   ├── auth/       # JWT + register/login
+│   │   ├── user/       # User entity, /api/users/me
+│   │   ├── market/     # search / publish / consume / mine
+│   │   └── config/     # Security, JPA
+│   └── src/main/resources/schema.sql
+├── openclaw/           # Local FastAPI node (Amar)
+│   └── app/
+│       ├── ollama_client.py    # embed + chat
+│       ├── market_client.py    # cloud client
+│       └── server.py           # /api/ask orchestrator + demo UI
+├── docker-compose.yml
+└── docs/
+    ├── marketplace.md          # design notes for this pivot
+    ├── proposal.md             # original ECE366 proposal (for reference)
+    ├── architecture.md         # old P2P-routing architecture (superseded)
+    └── agent-mode.md           # future: terminal/filesystem control
+```
+
+---
+
+## API
+
+### Cloud (Spring Boot, `:8080`)
+
+| Method | Path | Auth | Purpose |
+|---|---|---|---|
+| POST | `/api/auth/register` | no | create account |
+| POST | `/api/auth/login` | no | issue JWT |
+| GET | `/api/users/me` | yes | profile + credits |
+| POST | `/api/market/search` | yes | top-k by embedding |
+| POST | `/api/market/publish` | yes | add entry, earn bonus |
+| POST | `/api/market/consume` | yes | record use, pay royalty |
+| GET | `/api/market/mine` | yes | own published entries |
+
+### Local (FastAPI, `:8000`)
+
+| Method | Path | Purpose |
 |---|---|---|
-| F1 | User registration, login, JWT auth, profile management | In Progress |
-| F2 | Local AI chat interface (OpenClaw-based, already functional) | Done |
-| F3 | Node registry and online status heartbeat | In Progress |
-| F4 | Peer groups — create, invite, member list | In Progress|
-| F5 | Peer query routing via encrypted WebSocket relay | Testing |
-| F6 | Node dashboard — hardware stats, peer status | Planned |
-| F7 | Agent mode — terminal/kernel integration, filesystem-aware AI | Roadmap |
-| F8 | Distributed knowledge sharing — peer vector sync (stretch) | Stretch |
+| POST | `/api/login`, `/api/register` | pass-through to cloud |
+| GET | `/api/me` | current user |
+| POST | `/api/ask` | embed → search → verbatim/repackage/miss |
+| POST | `/api/publish` | publish last answer |
+
+---
+
+## What Changed From the Original Proposal
+
+The original MeshMind proposed peer query routing (send my prompt to your RTX 4090 via a WebSocket relay). That was cut. The marketplace replaces it with a stronger value proposition: **shared cache with attribution**, not borrowed hardware.
+
+- Cut: peer routing (F5), node heartbeat (F3), cloud conversation sync
+- Added: pgvector marketplace, credits ledger, three-mode ask orchestrator
+- Kept: local-first inference, privacy contract, Spring Boot + Postgres stack, Docker
+- Future: agent mode (filesystem + terminal control) — see `docs/agent-mode.md`
 
 ---
 
 ## Roadmap
 
-### Phase 1 — Backend Core (Sprint 1–2)
-- Spring Boot project setup with Docker + PostgreSQL
-- User auth: register, login, JWT, bcrypt
-- Node registry: heartbeat endpoint, online/offline tracking
-- REST API for groups: create, invite, list members
-
-### Phase 2 — Frontend Integration (Sprint 2–3)
-- Integrate OpenClaw chat UI with Spring Boot backend
-- Login/register screens
-- Group sidebar: member list, online status, model badges
-- Sync conversation history to PostgreSQL
-
-### Phase 3 — Peer Routing (Sprint 3–4)
-- WebSocket relay in Spring Boot
-- Client-side encryption (Web Crypto API / libsodium.js)
-- UI: "Ask peer" button, peer model selector
-- Node dashboard: GPU/RAM stats, peer status panel
-
-### Phase 4 — Agent Mode (Roadmap)
-- Terminal/kernel integration within the chat UI
-- Filesystem-aware AI with workspace scoping
-- Three-layer path safety (allowlist, traversal guard, destructive-op confirmation)
-- Plan-then-execute model: AI proposes actions, user approves before anything runs
-- Inspired by Claude Code — local, private, and IDE-embeddable
-
-### Phase 5 — Distributed Knowledge (Stretch)
-- Local document embeddings (not the documents themselves)
-- Peer vector sync within groups
-- Cross-peer RAG queries
-
----
-
-## Getting Started
-
-### Prerequisites
-- [Ollama](https://ollama.com) installed and running locally
-- Java 21+
-- Node.js 18+
-- Docker + docker-compose
-
-### Local Development
-
-```bash
-# Clone the repo
-git clone https://github.com/isaacamar/meshmind.git
-cd meshmind
-
-# Start PostgreSQL and Spring Boot via Docker
-docker-compose up -d
-
-# Start the React frontend
-cd frontend
-npm install
-npm run dev
-
-# The OpenClaw local chat backend (Python/FastAPI) runs separately
-cd openclaw
-pip install -r requirements.txt
-uvicorn app.server:app --reload --port 8000
-```
-
-> Full setup guide: [docs/setup.md](docs/setup.md) (coming soon)
-
----
-
-## Repository Structure
-
-```
-meshmind/
-├── backend/          # Spring Boot service (Java 21)
-│   └── src/
-├── frontend/         # React + TypeScript UI
-│   └── src/
-├── openclaw/         # Local FastAPI chat backend (Python)
-│   └── app/
-├── docs/             # Proposals, architecture, setup guides
-│   ├── proposal.md
-│   ├── agent-mode.md
-│   └── architecture.md
-├── docker-compose.yml
-└── README.md
-```
-
----
-
-## Contributing
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for branch conventions, PR process, and code standards.
-
-This project tracks work via GitHub Issues. Every PR requires at least one peer review before merge.
-
----
-
-## Team
-
-| Member | Role |
+| Milestone | Deliverable |
 |---|---|
-| [Isaac Amar](https://github.com/isaacamar) | React frontend, chat UI integration, local Ollama client, WebSocket client/relay, cloud deployment|
-| Isaac Schertz | Spring Boot backend, REST API, PostgreSQL schema, Docker |
-
-**Course:** ECE366 – Software Engineering & Large Systems Design
-**Institution:** The Cooper Union for the Advancement of Science and Art
-**Semester:** Spring 2026
+| **Now** | Auth, marketplace search/publish/consume, credits, demo UI |
+| **Next** | Streaming (SSE) in `/api/ask`, better repackage prompt, upvote/downvote |
+| **Demo** | Deploy cloud to AWS/GCP free tier; two-user end-to-end credit flow |
+| **Stretch** | Agent mode (read/write workspace files, run shell commands with approval) |
 
 ---
 
-## License
+## Course Context
 
-MIT — see [LICENSE](LICENSE).
+ECE366 — Software Engineering & Large Systems Design, Spring 2026, The Cooper Union.
+Team: Isaac Amar (local node + frontend), Isaac Schertz (Spring Boot backend).

--- a/docs/mac-setup.md
+++ b/docs/mac-setup.md
@@ -1,0 +1,91 @@
+# Mac Setup (M4, 24 GB unified memory)
+
+Target machine: MacBook Pro M4, 24 GB RAM. Everything is unified memory → acts as VRAM.
+Budget: ~8 GB for macOS/apps, ~14–16 GB for model + KV cache.
+Hard ceiling: 14B–20B models. Skip 32B+ on this box.
+
+## Prerequisites
+
+```bash
+# Install Homebrew if needed: https://brew.sh
+brew install ollama git python@3.11 jq
+brew install --cask docker
+
+# Start Ollama (background service)
+brew services start ollama
+# or one-shot: ollama serve &
+```
+
+## Model lineup
+
+```bash
+ollama pull qwen2.5-coder:14b          # coding daily driver
+ollama pull deepseek-r1:14b            # reasoning / debug
+ollama pull qwen2.5:14b-instruct-1m    # long context (up to ~64K practical)
+ollama pull gpt-oss:20b                # general / agent — tight fit
+ollama pull qwen2.5vl:7b               # vision
+ollama pull nomic-embed-text           # embeddings (matches schema vector(768))
+ollama pull qwen2.5-coder:7b           # fast autocomplete
+```
+
+## Long-context Modelfiles (Ollama defaults to 2048 tokens)
+
+```bash
+cat > /tmp/Modelfile.coder <<'EOF'
+FROM qwen2.5-coder:14b
+PARAMETER num_ctx 65536
+EOF
+ollama create qwen2.5-coder-long -f /tmp/Modelfile.coder
+
+cat > /tmp/Modelfile.r1 <<'EOF'
+FROM deepseek-r1:14b
+PARAMETER num_ctx 32768
+EOF
+ollama create deepseek-r1-long -f /tmp/Modelfile.r1
+```
+
+## Running the repo
+
+```bash
+cd ~/meshmind-v2
+
+# 1. cloud stack
+docker compose up -d --build
+docker compose logs -f backend    # wait for "Started MeshMindApplication"
+
+# 2. local node
+cd openclaw
+python3.11 -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+
+# choose default chat model via env var (defaults to qwen2.5-coder:14b)
+export MESHMIND_CHAT_MODEL=qwen2.5-coder-long
+uvicorn app.server:app --reload --port 8000
+
+# 3. open http://localhost:8000
+```
+
+## Env vars
+
+| Var | Default | Purpose |
+|---|---|---|
+| `OLLAMA_URL` | `http://localhost:11434` | Point the node at a remote Ollama (e.g. another machine) |
+| `MESHMIND_CHAT_MODEL` | `qwen2.5-coder:14b` | Default chat model |
+| `MESHMIND_EMBED_MODEL` | `nomic-embed-text` | Must stay 768-dim to match schema |
+| `MESHMIND_CLOUD` | `http://localhost:8080` | Cloud API base URL |
+
+## Sanity checks
+
+```bash
+ollama list
+ollama ps                                       # see loaded model + context size
+curl http://localhost:11434/api/tags | jq .
+curl http://localhost:8080/actuator/health 2>/dev/null
+```
+
+## Mac-specific gotchas
+
+- **Docker Desktop memory**: default 2 GB is fine for Postgres+Spring Boot, bump to 4 GB if backend OOMs. Settings → Resources.
+- **Metal flash-attention**: Ollama enables automatically. Past ~64K context on Metal, throughput drops faster than on CUDA — keep `num_ctx` conservative.
+- **Activity Monitor → Memory tab** shows real pressure. Yellow/red = close apps before loading models.
+- **Don't** pull 32B models. They load but eat all memory, making the OS swap and the demo crawl.

--- a/docs/marketplace.md
+++ b/docs/marketplace.md
@@ -1,0 +1,80 @@
+# Prompt Marketplace — Design Notes
+
+## Why this, not peer routing
+
+The original MeshMind proposed routing prompts to friends' GPUs over an encrypted relay. That doesn't solve a real user problem — my local Ollama is already fine. What the network *can* give me is **other people's past answers**, semantically indexed, with attribution.
+
+This is the moat. It gets stronger the more users publish. Peer routing doesn't — a busy peer is worse than a free local model.
+
+## Three-mode `/api/ask`
+
+```
+prompt
+  │
+  ▼ local embed (nomic-embed-text, 768 dims)
+  │
+  ▼ POST /api/market/search {embedding, k=3}
+  │
+  ┌──────────────┬──────────────┬────────────┐
+  ▼              ▼              ▼            ▼
+sim ≥ 0.90     0.70–0.90     < 0.70       cloud offline
+verbatim       repackage      miss         fallback to miss
+  │              │              │
+  ▼              ▼              ▼
+return          local chat     local chat
+cached          with cached    fresh
+response        as context     response
+  │              │              │
+  ▼              ▼              ▼
+/consume        /consume       (offer publish)
+(pay author)    (pay author)   (earn bonus)
+```
+
+### Repackage prompt template
+
+```
+A user asks: {prompt}
+
+A similar question was previously answered as follows:
+---
+{cached_response}
+---
+
+Rewrite this answer to address the user's exact question.
+Be concise — do not repeat information the user didn't ask for.
+```
+
+This typically runs in ~50–100 output tokens versus 300–800 for a fresh answer on the same topic, because the model is adapting, not generating from scratch.
+
+## Credits economy
+
+Kept deliberately simple — no blockchain, no token, just a Postgres `users.credits` column plus an immutable `credit_events` ledger.
+
+| Event | Delta | Who |
+|---|---|---|
+| Register | +100 | new user |
+| Publish an entry | +5 | author |
+| Entry consumed | +1 | author |
+| Search | 0 | (free for now) |
+| Fresh inference | 0 | (you ran it locally, no cost to the network) |
+
+Room to tighten later: rate-limited free searches, paid search above quota, upvote/downvote effects on search ranking.
+
+## Privacy contract
+
+- Embeddings: leave the machine for search, but they're not reversible to plaintext for practical purposes with a 768-dim float vector.
+- Plaintext prompts + responses: **only** sent to the cloud when the user clicks Publish.
+- Everything else stays in local SQLite (planned — current demo is stateless for simplicity).
+
+## pgvector choices
+
+- **IVFFlat** index with `lists=100`. Fine up to ~100k entries. Revisit HNSW if it grows.
+- **Cosine distance** (`<=>` operator), converted to similarity as `1 - distance`.
+- Index is created in `schema.sql` and loaded at container init.
+
+## Open questions
+
+- **Embedding drift**: if we ever swap embedding models, old entries become un-searchable. Mitigation: store `embedding_model` per entry, allow filtered search.
+- **Response quality decay**: an answer that was right in 2026 may be wrong in 2028. Add freshness weights to ranking.
+- **Trolling/garbage**: add `flag` action, threshold for auto-hide, staked moderation later.
+- **Exact-match vs. semantic**: currently only vector search. Could add lexical (Postgres FTS) as a second-pass filter.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,8 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>⬡</text></svg>" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>MeshMind</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css" />
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,19 +1,25 @@
 {
-  "name": "meshmind-frontend",
+  "name": "meshmind-v2-frontend",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "meshmind-frontend",
+      "name": "meshmind-v2-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "katex": "^0.16.11",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-markdown": "^9.0.1",
+        "react-syntax-highlighter": "^15.5.0",
+        "rehype-katex": "^7.0.0",
+        "remark-math": "^6.0.0"
       },
       "devDependencies": {
         "@types/react": "^18.3.1",
         "@types/react-dom": "^18.3.1",
+        "@types/react-syntax-highlighter": "^15.5.13",
         "@vitejs/plugin-react": "^4.3.1",
         "typescript": "^5.5.3",
         "vite": "^5.4.2"
@@ -251,6 +257,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -750,9 +765,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.0.tgz",
-      "integrity": "sha512-WOhNW9K8bR3kf4zLxbfg6Pxu2ybOUbB2AjMDHSQx86LIF4rH4Ft7vmMwNt0loO0eonglSNy4cpD3MKXXKQu0/A==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
       "cpu": [
         "arm"
       ],
@@ -764,9 +779,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.0.tgz",
-      "integrity": "sha512-u6JHLll5QKRvjciE78bQXDmqRqNs5M/3GVqZeMwvmjaNODJih/WIrJlFVEihvV0MiYFmd+ZyPr9wxOVbPAG2Iw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
       "cpu": [
         "arm64"
       ],
@@ -778,9 +793,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.0.tgz",
-      "integrity": "sha512-qEF7CsKKzSRc20Ciu2Zw1wRrBz4g56F7r/vRwY430UPp/nt1x21Q/fpJ9N5l47WWvJlkNCPJz3QRVw008fi7yA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
       "cpu": [
         "arm64"
       ],
@@ -792,9 +807,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.0.tgz",
-      "integrity": "sha512-WADYozJ4QCnXCH4wPB+3FuGmDPoFseVCUrANmA5LWwGmC6FL14BWC7pcq+FstOZv3baGX65tZ378uT6WG8ynTw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
       "cpu": [
         "x64"
       ],
@@ -806,9 +821,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.0.tgz",
-      "integrity": "sha512-6b8wGHJlDrGeSE3aH5mGNHBjA0TTkxdoNHik5EkvPHCt351XnigA4pS7Wsj/Eo9Y8RBU6f35cjN9SYmCFBtzxw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
       "cpu": [
         "arm64"
       ],
@@ -820,9 +835,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.0.tgz",
-      "integrity": "sha512-h25Ga0t4jaylMB8M/JKAyrvvfxGRjnPQIR8lnCayyzEjEOx2EJIlIiMbhpWxDRKGKF8jbNH01NnN663dH638mA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
       "cpu": [
         "x64"
       ],
@@ -834,9 +849,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.0.tgz",
-      "integrity": "sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
       "cpu": [
         "arm"
       ],
@@ -848,9 +863,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.0.tgz",
-      "integrity": "sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
       "cpu": [
         "arm"
       ],
@@ -862,9 +877,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.0.tgz",
-      "integrity": "sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
       "cpu": [
         "arm64"
       ],
@@ -876,9 +891,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.0.tgz",
-      "integrity": "sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
       "cpu": [
         "arm64"
       ],
@@ -890,9 +905,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.0.tgz",
-      "integrity": "sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
       "cpu": [
         "loong64"
       ],
@@ -904,9 +919,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.0.tgz",
-      "integrity": "sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
       "cpu": [
         "loong64"
       ],
@@ -918,9 +933,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.0.tgz",
-      "integrity": "sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
       "cpu": [
         "ppc64"
       ],
@@ -932,9 +947,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.0.tgz",
-      "integrity": "sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
       "cpu": [
         "ppc64"
       ],
@@ -946,9 +961,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.0.tgz",
-      "integrity": "sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
       "cpu": [
         "riscv64"
       ],
@@ -960,9 +975,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.0.tgz",
-      "integrity": "sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
       "cpu": [
         "riscv64"
       ],
@@ -974,9 +989,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.0.tgz",
-      "integrity": "sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
       "cpu": [
         "s390x"
       ],
@@ -988,9 +1003,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.0.tgz",
-      "integrity": "sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
       "cpu": [
         "x64"
       ],
@@ -1002,9 +1017,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.0.tgz",
-      "integrity": "sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
       "cpu": [
         "x64"
       ],
@@ -1016,9 +1031,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.0.tgz",
-      "integrity": "sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
       "cpu": [
         "x64"
       ],
@@ -1030,9 +1045,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.0.tgz",
-      "integrity": "sha512-pESDkos/PDzYwtyzB5p/UoNU/8fJo68vcXM9ZW2V0kjYayj1KaaUfi1NmTUTUpMn4UhU4gTuK8gIaFO4UGuMbA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
       "cpu": [
         "arm64"
       ],
@@ -1044,9 +1059,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.0.tgz",
-      "integrity": "sha512-hj1wFStD7B1YBeYmvY+lWXZ7ey73YGPcViMShYikqKT1GtstIKQAtfUI6yrzPjAy/O7pO0VLXGmUVWXQMaYgTQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
       "cpu": [
         "arm64"
       ],
@@ -1058,9 +1073,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.0.tgz",
-      "integrity": "sha512-SyaIPFoxmUPlNDq5EHkTbiKzmSEmq/gOYFI/3HHJ8iS/v1mbugVa7dXUzcJGQfoytp9DJFLhHH4U3/eTy2Bq4w==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
       "cpu": [
         "ia32"
       ],
@@ -1072,9 +1087,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.0.tgz",
-      "integrity": "sha512-RdcryEfzZr+lAr5kRm2ucN9aVlCCa2QNq4hXelZxb8GG0NJSazq44Z3PCCc8wISRuCVnGs0lQJVX5Vp6fKA+IA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
       "cpu": [
         "x64"
       ],
@@ -1086,9 +1101,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.0.tgz",
-      "integrity": "sha512-PrsWNQ8BuE00O3Xsx3ALh2Df8fAj9+cvvX9AIA6o4KpATR98c9mud4XtDWVvsEuyia5U4tVSTKygawyJkjm60w==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
       "cpu": [
         "x64"
       ],
@@ -1144,25 +1159,70 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/katex": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
+      "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -1178,6 +1238,28 @@
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
+    },
+    "node_modules/@types/react-syntax-highlighter": {
+      "version": "15.5.13",
+      "resolved": "https://registry.npmjs.org/@types/react-syntax-highlighter/-/react-syntax-highlighter-15.5.13.tgz",
+      "integrity": "sha512-uLGJ87j6Sz8UaBAooU0T6lWJ0dBmjZgN1PZTrj05TNql2/XpC6+4HhMT5syIdFUUt+FASfCeLLv4kBygNU+8qA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "license": "ISC"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -1200,10 +1282,20 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.10",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.10.tgz",
-      "integrity": "sha512-sUoJ3IMxx4AyRqO4MLeHlnGDkyXRoUG0/AI9fjK+vS72ekpV0yWVY7O0BVjmBcRtkNcsAO2QDZ4tdKKGoI6YaQ==",
+      "version": "2.10.18",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.18.tgz",
+      "integrity": "sha512-VSnGQAOLtP5mib/DPyg2/t+Tlv65NTBz83BJBJvmLVHHuKJVaDOBvJJykiT5TR++em5nfAySPccDZDa4oSrn8A==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1214,9 +1306,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "dev": true,
       "funding": [
         {
@@ -1234,11 +1326,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1248,9 +1340,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001781",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001781.tgz",
-      "integrity": "sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==",
+      "version": "1.0.30001787",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001787.tgz",
+      "integrity": "sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==",
       "dev": true,
       "funding": [
         {
@@ -1268,6 +1360,75 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1279,14 +1440,12 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1300,12 +1459,59 @@
         }
       }
     },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.321",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.321.tgz",
-      "integrity": "sha512-L2C7Q279W2D/J4PLZLk7sebOILDSWos7bMsMNN06rK482umHUrh/3lM8G7IlHFOYip2oAg5nha1rCMxr/rs6ZQ==",
+      "version": "1.5.335",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.335.tgz",
+      "integrity": "sha512-q9n5T4BR4Xwa2cwbrwcsDJtHD/enpQ5S1xF1IAtdqf5AAgqDFmR/aakqH3ChFdqd/QXJhS3rnnXFtexU7rax6Q==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -1356,6 +1562,43 @@
         "node": ">=6"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fault": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.4.tgz",
+      "integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
+      "license": "MIT",
+      "dependencies": {
+        "format": "^0.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/format": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+      "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1379,6 +1622,366 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/hast-util-from-dom": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-from-dom/-/hast-util-from-dom-5.0.1.tgz",
+      "integrity": "sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q==",
+      "license": "ISC",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hastscript": "^9.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-dom/node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-dom/node_modules/hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+      "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.1.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "parse5": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html-isomorphic": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html-isomorphic/-/hast-util-from-html-isomorphic-2.0.0.tgz",
+      "integrity": "sha512-zJfpXq44yff2hmE0XmwEOzdWin5xwH+QIhMLOScpX91e/NSGPsAzNCvLQDIEPyO2TXi+lBmU6hjLIhV8MwP2kw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-from-dom": "^5.0.0",
+        "hast-util-from-html": "^2.0.0",
+        "unist-util-remove-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-parse5": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "hastscript": "^9.0.0",
+        "property-information": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-location": "^5.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-parse5/node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-parse5/node_modules/hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-is-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz",
+      "integrity": "sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-text": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unist-util-find-after": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-6.0.0.tgz",
+      "integrity": "sha512-nDM6bvd7lIqDUiYEiu5Sl/+6ReP0BMk/2f4U/Rooccxkj0P5nm+acM5PrGJ/t5I8qPGiqZSE6hVAwZEdZIvP4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "comma-separated-tokens": "^1.0.0",
+        "hast-util-parse-selector": "^2.0.0",
+        "property-information": "^5.0.0",
+        "space-separated-tokens": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript/node_modules/@types/hast": {
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.10.tgz",
+      "integrity": "sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2"
+      }
+    },
+    "node_modules/hastscript/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
+    "node_modules/hastscript/node_modules/comma-separated-tokens": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz",
+      "integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/hastscript/node_modules/property-information": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.6.0.tgz",
+      "integrity": "sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/hastscript/node_modules/space-separated-tokens": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz",
+      "integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/highlightjs-vue": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/highlightjs-vue/-/highlightjs-vue-1.0.0.tgz",
+      "integrity": "sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/js-tokens": {
@@ -1413,6 +2016,32 @@
         "node": ">=6"
       }
     },
+    "node_modules/katex": {
+      "version": "0.16.45",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.45.tgz",
+      "integrity": "sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -1425,6 +2054,20 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lowlight": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.20.0.tgz",
+      "integrity": "sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==",
+      "license": "MIT",
+      "dependencies": {
+        "fault": "^1.0.0",
+        "highlight.js": "~10.7.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -1435,11 +2078,643 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-math": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-math/-/mdast-util-math-3.0.0.tgz",
+      "integrity": "sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.1.0",
+        "unist-util-remove-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-math": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
+      "integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/katex": "^0.16.0",
+        "devlop": "^1.0.0",
+        "katex": "^0.16.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -1462,11 +2737,48 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.36",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
-      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "version": "2.0.37",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
+      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -1476,9 +2788,9 @@
       "license": "ISC"
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
+      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
       "dev": true,
       "funding": [
         {
@@ -1502,6 +2814,25 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prismjs": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/react": {
@@ -1529,6 +2860,33 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-markdown": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-9.1.0.tgz",
+      "integrity": "sha512-xaijuJB0kzGiUdG7nc2MOMDUDBWPyGAjZtUrow9XxUeua8IqeP+VlIfAZ3bphpcLTnSZXz6z9jcVC/TCwbfgdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -1539,10 +2897,211 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-syntax-highlighter": {
+      "version": "15.6.6",
+      "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-15.6.6.tgz",
+      "integrity": "sha512-DgXrc+AZF47+HvAPEmn7Ua/1p10jNoVZVI/LoPiYdtY+OM+/nG5yefLHKJwdKqY1adMuHFbeyBaG9j64ML7vTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.3.1",
+        "highlight.js": "^10.4.1",
+        "highlightjs-vue": "^1.0.0",
+        "lowlight": "^1.17.0",
+        "prismjs": "^1.30.0",
+        "refractor": "^3.6.0"
+      },
+      "peerDependencies": {
+        "react": ">= 0.14.0"
+      }
+    },
+    "node_modules/refractor": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/refractor/-/refractor-3.6.0.tgz",
+      "integrity": "sha512-MY9W41IOWxxk31o+YvFCNyNzdkc9M20NoZK5vq6jkv4I/uh2zkWcfudj0Q1fovjUQJrNewS9NMzeTtqPf+n5EA==",
+      "license": "MIT",
+      "dependencies": {
+        "hastscript": "^6.0.0",
+        "parse-entities": "^2.0.0",
+        "prismjs": "~1.27.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/refractor/node_modules/character-entities": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
+      "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/refractor/node_modules/character-entities-legacy": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
+      "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/refractor/node_modules/character-reference-invalid": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
+      "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/refractor/node_modules/is-alphabetical": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
+      "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/refractor/node_modules/is-alphanumerical": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
+      "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^1.0.0",
+        "is-decimal": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/refractor/node_modules/is-decimal": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
+      "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/refractor/node_modules/is-hexadecimal": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
+      "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/refractor/node_modules/parse-entities": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
+      "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "character-reference-invalid": "^1.0.0",
+        "is-alphanumerical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-hexadecimal": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/refractor/node_modules/prismjs": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz",
+      "integrity": "sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/rehype-katex": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-katex/-/rehype-katex-7.0.1.tgz",
+      "integrity": "sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/katex": "^0.16.0",
+        "hast-util-from-html-isomorphic": "^2.0.0",
+        "hast-util-to-text": "^4.0.0",
+        "katex": "^0.16.0",
+        "unist-util-visit-parents": "^6.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-math": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/remark-math/-/remark-math-6.0.0.tgz",
+      "integrity": "sha512-MMqgnP74Igy+S3WwnhQ7kqGlEerTETXMvJhrUzDikVZ2/uogJCb+WHUg97hK9/jcfc0dkD73s3LN8zU49cTEtA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-math": "^3.0.0",
+        "micromark-extension-math": "^3.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/rollup": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.0.tgz",
-      "integrity": "sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1556,31 +3115,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.0",
-        "@rollup/rollup-android-arm64": "4.60.0",
-        "@rollup/rollup-darwin-arm64": "4.60.0",
-        "@rollup/rollup-darwin-x64": "4.60.0",
-        "@rollup/rollup-freebsd-arm64": "4.60.0",
-        "@rollup/rollup-freebsd-x64": "4.60.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.0",
-        "@rollup/rollup-linux-arm64-musl": "4.60.0",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.0",
-        "@rollup/rollup-linux-loong64-musl": "4.60.0",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.0",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.0",
-        "@rollup/rollup-linux-x64-gnu": "4.60.0",
-        "@rollup/rollup-linux-x64-musl": "4.60.0",
-        "@rollup/rollup-openbsd-x64": "4.60.0",
-        "@rollup/rollup-openharmony-arm64": "4.60.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.0",
-        "@rollup/rollup-win32-x64-gnu": "4.60.0",
-        "@rollup/rollup-win32-x64-msvc": "4.60.0",
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
         "fsevents": "~2.3.2"
       }
     },
@@ -1613,6 +3172,68 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -1625,6 +3246,121 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-find-after": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-remove-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
+      "integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -1656,6 +3392,48 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-location": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/vite": {
@@ -1718,12 +3496,41 @@
         }
       }
     },
+    "node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     }
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "meshmind-frontend",
+  "name": "meshmind-v2-frontend",
   "private": true,
   "version": "0.1.0",
   "type": "module",
@@ -10,11 +10,17 @@
   },
   "dependencies": {
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-markdown": "^9.0.1",
+    "remark-math": "^6.0.0",
+    "rehype-katex": "^7.0.0",
+    "katex": "^0.16.11",
+    "react-syntax-highlighter": "^15.5.0"
   },
   "devDependencies": {
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.1",
+    "@types/react-syntax-highlighter": "^15.5.13",
     "@vitejs/plugin-react": "^4.3.1",
     "typescript": "^5.5.3",
     "vite": "^5.4.2"

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -4,7 +4,7 @@
   width: 100vw;
 }
 
-/* Sidebar */
+/* ── Sidebar ──────────────────────────────────────────────────────────────── */
 .sidebar {
   width: 260px;
   min-width: 260px;
@@ -24,10 +24,23 @@
   flex-direction: column;
   gap: 8px;
 }
+
 .logo { font-size: 1.1rem; font-weight: 700; color: #7c6af7; letter-spacing: 0.5px; }
 
-.user-info { display: flex; align-items: center; justify-content: space-between; }
-.user-name { font-size: 0.8rem; color: #888; }
+.user-info { display: flex; align-items: center; gap: 6px; }
+.user-name { font-size: 0.8rem; color: #888; flex: 1; }
+
+.credits-badge {
+  font-size: 0.72rem;
+  background: #27224a;
+  color: #a99cf5;
+  border: 1px solid #3d356e;
+  border-radius: 10px;
+  padding: 2px 8px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
 .logout-btn {
   background: none;
   border: none;
@@ -63,6 +76,67 @@
   cursor: pointer;
 }
 
+/* ── Model capability tags ─────────────────────────────────────────────────── */
+.model-tags { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 6px; }
+.model-tag-pill {
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  border: 1px solid;
+  border-radius: 4px;
+  padding: 1px 6px;
+  background: transparent;
+  opacity: 0.85;
+}
+
+/* ── Temperature slider ────────────────────────────────────────────────────── */
+.temp-slider-wrap { display: flex; flex-direction: column; gap: 4px; }
+
+.temp-slider-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+.temp-slider-header label { font-size: 0.72rem; color: #888; text-transform: uppercase; letter-spacing: 0.5px; }
+.temp-label { font-size: 0.72rem; font-weight: 600; }
+
+.temp-slider {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  height: 4px;
+  border-radius: 2px;
+  background: linear-gradient(to right, #4bc8f0 0%, #3dba6c 30%, #f0b429 60%, #e05c7a 100%);
+  outline: none;
+  cursor: pointer;
+}
+.temp-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--thumb-color, #7c6af7);
+  border: 2px solid #0f0f0f;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.temp-slider::-moz-range-thumb {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--thumb-color, #7c6af7);
+  border: 2px solid #0f0f0f;
+  cursor: pointer;
+}
+.temp-ticks {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.62rem;
+  color: #444;
+  margin-top: 2px;
+}
+
 .new-chat-btn {
   background: #7c6af7;
   color: #fff;
@@ -78,6 +152,7 @@
 .new-chat-btn:disabled { background: #444; cursor: not-allowed; }
 
 .session-list { flex: 1; overflow-y: auto; display: flex; flex-direction: column; gap: 4px; }
+
 .session-item {
   display: flex;
   align-items: center;
@@ -90,8 +165,27 @@
 }
 .session-item:hover { background: #222; }
 .session-item.active { background: #27224a; }
-.session-title { flex: 1; font-size: 0.85rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.session-model { font-size: 0.7rem; color: #666; white-space: nowrap; }
+
+.session-title {
+  flex: 1;
+  font-size: 0.85rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  cursor: text;
+}
+.session-rename-input {
+  flex: 1;
+  background: #2a2a2a;
+  border: 1px solid #7c6af7;
+  border-radius: 4px;
+  color: #e8e8e8;
+  font-size: 0.85rem;
+  padding: 1px 6px;
+  outline: none;
+  min-width: 0;
+}
+.session-model { font-size: 0.7rem; color: #555; white-space: nowrap; }
 .delete-btn {
   background: none; border: none; color: #555; font-size: 0.75rem;
   cursor: pointer; padding: 2px 4px; border-radius: 3px; opacity: 0;
@@ -100,10 +194,10 @@
 .session-item:hover .delete-btn { opacity: 1; }
 .delete-btn:hover { color: #f66; }
 
-/* Main area */
+/* ── Main area ─────────────────────────────────────────────────────────────── */
 .main { flex: 1; display: flex; flex-direction: column; overflow: hidden; }
 
-/* Empty state */
+/* ── Empty state ───────────────────────────────────────────────────────────── */
 .empty-state {
   flex: 1;
   display: flex;
@@ -128,6 +222,7 @@
   font-size: 0.95rem;
   font-weight: 600;
   cursor: pointer;
+  transition: background 0.15s;
 }
 .start-btn:hover { background: #6a58e5; }
 .hint { font-size: 0.85rem !important; }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,99 +1,158 @@
-import { useState, useEffect, useRef } from 'react'
-import Chat from './components/Chat'
+import { useState, useEffect } from 'react'
 import AuthPage from './components/AuthPage'
-import GroupsPanel from './components/GroupsPanel'
-import GroupChat from './components/GroupChat'
-import { isLoggedIn, getStoredUser, logout, heartbeat, type Group } from './api/cloud'
+import Chat from './components/Chat'
+import { modelTags, TAG_COLORS, tempLabel, tempColor } from './utils/models'
 import './App.css'
 
-interface Session {
+export interface LocalMessage {
+  role: 'user' | 'assistant' | 'system'
+  content: string
+  // Which model generated this response (assistant messages only)
+  model?: string
+  mode?: 'verbatim' | 'repackage' | 'miss'
+  source_author?: string
+  similarity?: number
+  source_entry_id?: string
+  embedding?: number[]
+  published?: boolean
+  // Attachment metadata (name/type only — raw bytes are not persisted)
+  attachmentType?: 'image' | 'pdf'
+  attachmentName?: string
+  // Token usage (assistant messages only)
+  tokensIn?: number
+  tokensOut?: number
+  toksPerSec?: number | null
+}
+
+export interface LocalSession {
   id: string
   title: string
   model: string
+  messages: LocalMessage[]
   created_at: string
 }
 
+function loadSessions(): LocalSession[] {
+  try {
+    return JSON.parse(localStorage.getItem('mm_sessions') ?? '[]')
+  } catch {
+    return []
+  }
+}
+
+function saveSessions(sessions: LocalSession[]) {
+  localStorage.setItem('mm_sessions', JSON.stringify(sessions))
+}
+
+function getStoredUser(): { username: string } | null {
+  try {
+    return JSON.parse(localStorage.getItem('mm_user') ?? 'null')
+  } catch {
+    return null
+  }
+}
+
 export default function App() {
-  const [authed, setAuthed] = useState(isLoggedIn())
-  const user = getStoredUser()
+  const [authed, setAuthed] = useState(() => !!getStoredUser())
+  const [username, setUsername] = useState(() => getStoredUser()?.username ?? '')
+  const [credits, setCredits] = useState<number | null>(null)
 
-  const [sessions, setSessions] = useState<Session[]>([])
-  const [activeSession, setActiveSession] = useState<string | null>(null)
-  const [activeGroup, setActiveGroup] = useState<Group | null>(null)
+  const [sessions, setSessions] = useState<LocalSession[]>(loadSessions)
+  const [activeId, setActiveId] = useState<string | null>(null)
+  const [renamingId, setRenamingId] = useState<string | null>(null)
+  const [renameValue, setRenameValue] = useState('')
+
   const [models, setModels] = useState<string[]>([])
-  const [selectedModel, setSelectedModel] = useState<string>('')
+  const [selectedModel, setSelectedModel] = useState('')
   const [ollamaOk, setOllamaOk] = useState<boolean | null>(null)
-  const heartbeatRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const [temperature, setTemperature] = useState(0.7)
 
-  // Load models + sessions on mount / after login
+  // Load models + credits on login
   useEffect(() => {
     if (!authed) return
-
     fetch('/api/models')
       .then(r => r.json())
       .then(d => {
-        setModels(d.models || [])
-        if (d.models?.length) setSelectedModel(d.models[0])
-        setOllamaOk(true)
-        // Send first heartbeat with current model list
-        heartbeat(d.models || [], 24.0).catch(() => {})
+        const list: string[] = d.models ?? []
+        setModels(list)
+        if (list.length) setSelectedModel(list[0])
+        setOllamaOk(list.length > 0)
       })
       .catch(() => setOllamaOk(false))
 
-    fetch('/api/sessions')
+    fetch('/api/me')
       .then(r => r.json())
-      .then(setSessions)
+      .then(d => setCredits(d.credits ?? null))
       .catch(() => {})
-
-    // Heartbeat every 60s while logged in
-    heartbeatRef.current = setInterval(() => {
-      heartbeat(models, 24.0).catch(() => {})
-    }, 60_000)
-
-    return () => {
-      if (heartbeatRef.current) clearInterval(heartbeatRef.current)
-    }
   }, [authed])
 
-  const handleAuth = () => setAuthed(true)
+  // Persist sessions to localStorage whenever they change
+  useEffect(() => {
+    saveSessions(sessions)
+  }, [sessions])
 
-  const handleLogout = () => {
-    if (heartbeatRef.current) clearInterval(heartbeatRef.current)
-    logout()
+  // Sync dropdown to the active session's model when switching sessions
+  useEffect(() => {
+    if (activeId) {
+      const s = sessions.find(s => s.id === activeId)
+      if (s && s.model && models.includes(s.model)) setSelectedModel(s.model)
+    }
+  }, [activeId])
+
+  const handleAuth = (user: string) => {
+    setUsername(user)
+    setAuthed(true)
+  }
+
+  const handleLogout = async () => {
+    await fetch('/api/login', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ username: '', password: '' }) }).catch(() => {})
+    localStorage.removeItem('mm_user')
     setAuthed(false)
-    setSessions([])
-    setActiveSession(null)
-    setActiveGroup(null)
+    setUsername('')
+    setCredits(null)
+    setActiveId(null)
   }
 
-  const openGroup = (group: Group) => {
-    setActiveGroup(group)
-    setActiveSession(null)
-  }
-
-  const openSession = (id: string) => {
-    setActiveSession(id)
-    setActiveGroup(null)
-  }
-
-  const newSession = async () => {
+  const newSession = () => {
     if (!selectedModel) return
-    const res = await fetch('/api/sessions', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ model: selectedModel, title: 'New Chat' }),
-    })
-    const s = await res.json()
+    const s: LocalSession = {
+      id: crypto.randomUUID(),
+      title: 'New chat',
+      model: selectedModel,
+      messages: [],
+      created_at: new Date().toISOString(),
+    }
     setSessions(prev => [s, ...prev])
-    setActiveSession(s.id)
+    setActiveId(s.id)
   }
 
-  const deleteSession = async (id: string, e: React.MouseEvent) => {
-    e.stopPropagation()
-    await fetch(`/api/sessions/${id}`, { method: 'DELETE' })
-    setSessions(prev => prev.filter(s => s.id !== id))
-    if (activeSession === id) setActiveSession(null)
+  const updateSession = (updated: LocalSession) => {
+    setSessions(prev => prev.map(s => s.id === updated.id ? updated : s))
   }
+
+  const deleteSession = (id: string, e: React.MouseEvent) => {
+    e.stopPropagation()
+    setSessions(prev => prev.filter(s => s.id !== id))
+    if (activeId === id) setActiveId(null)
+  }
+
+  const startRename = (s: LocalSession, e: React.MouseEvent) => {
+    e.stopPropagation()
+    setRenamingId(s.id)
+    setRenameValue(s.title)
+  }
+
+  const commitRename = (id: string) => {
+    const title = renameValue.trim()
+    if (title) setSessions(prev => prev.map(s => s.id === id ? { ...s, title } : s))
+    setRenamingId(null)
+  }
+
+  const onCreditsEarned = (earned: number) => {
+    setCredits(prev => (prev ?? 0) + earned)
+  }
+
+  const activeSession = sessions.find(s => s.id === activeId) ?? null
 
   if (!authed) return <AuthPage onAuth={handleAuth} />
 
@@ -103,7 +162,10 @@ export default function App() {
         <div className="sidebar-header">
           <span className="logo">⬡ MeshMind</span>
           <div className="user-info">
-            <span className="user-name">{user?.username}</span>
+            <span className="user-name">{username}</span>
+            {credits !== null && (
+              <span className="credits-badge" title="Marketplace credits">{credits} cr</span>
+            )}
             <button className="logout-btn" onClick={handleLogout} title="Log out">↪</button>
           </div>
         </div>
@@ -111,16 +173,70 @@ export default function App() {
         {ollamaOk === false && (
           <div className="ollama-warn">
             ⚠ Ollama not running<br />
-            <code>OLLAMA_HOST=0.0.0.0 ollama serve</code>
+            <code>ollama serve</code>
           </div>
         )}
 
         <div className="model-select">
           <label>Model</label>
-          <select value={selectedModel} onChange={e => setSelectedModel(e.target.value)}>
+          <select value={selectedModel} onChange={e => {
+            const newModel = e.target.value
+            setSelectedModel(newModel)
+            if (activeId) {
+              setSessions(prev => prev.map(s => {
+                if (s.id !== activeId) return s
+                // Only insert separator if we actually changed the model and the
+                // session already has messages (no point flagging a switch on an empty chat)
+                const changed = s.model !== newModel
+                const hasMessages = s.messages.length > 0
+                const separator: LocalMessage | null =
+                  changed && hasMessages
+                    ? { role: 'system', content: `Switched to ${newModel}`, model: newModel }
+                    : null
+                return {
+                  ...s,
+                  model: newModel,
+                  messages: separator ? [...s.messages, separator] : s.messages,
+                }
+              }))
+            }
+          }}>
             {models.length === 0 && <option>No models found</option>}
             {models.map(m => <option key={m} value={m}>{m}</option>)}
           </select>
+          {selectedModel && (
+            <div className="model-tags">
+              {modelTags(selectedModel).map(tag => (
+                <span
+                  key={tag}
+                  className="model-tag-pill"
+                  style={{ color: TAG_COLORS[tag], borderColor: TAG_COLORS[tag] }}
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className="temp-slider-wrap">
+          <div className="temp-slider-header">
+            <label>Temperature</label>
+            <span className="temp-label" style={{ color: tempColor(temperature) }}>
+              {tempLabel(temperature)} · {temperature.toFixed(2)}
+            </span>
+          </div>
+          <input
+            type="range"
+            min={0} max={2} step={0.05}
+            value={temperature}
+            onChange={e => setTemperature(parseFloat(e.target.value))}
+            className="temp-slider"
+            style={{ '--thumb-color': tempColor(temperature) } as React.CSSProperties}
+          />
+          <div className="temp-ticks">
+            <span>Precise</span><span>Balanced</span><span>Creative</span><span>Chaotic</span>
+          </div>
         </div>
 
         <button className="new-chat-btn" onClick={newSession} disabled={!selectedModel}>
@@ -131,36 +247,52 @@ export default function App() {
           {sessions.map(s => (
             <div
               key={s.id}
-              className={`session-item ${s.id === activeSession ? 'active' : ''}`}
-              onClick={() => openSession(s.id)}
+              className={`session-item ${s.id === activeId ? 'active' : ''}`}
+              onClick={() => setActiveId(s.id)}
             >
-              <span className="session-title">{s.title}</span>
-              <span className="session-model">{s.model}</span>
+              {renamingId === s.id ? (
+                <input
+                  className="session-rename-input"
+                  value={renameValue}
+                  onChange={e => setRenameValue(e.target.value)}
+                  onBlur={() => commitRename(s.id)}
+                  onKeyDown={e => {
+                    if (e.key === 'Enter') commitRename(s.id)
+                    if (e.key === 'Escape') setRenamingId(null)
+                  }}
+                  onClick={e => e.stopPropagation()}
+                  autoFocus
+                />
+              ) : (
+                <span className="session-title" onDoubleClick={e => startRename(s, e)}>{s.title}</span>
+              )}
+              <span className="session-model">{s.model.split(':')[0]}</span>
               <button className="delete-btn" onClick={e => deleteSession(s.id, e)}>✕</button>
             </div>
           ))}
         </div>
-
-        <GroupsPanel onSelectGroup={openGroup} activeGroupId={activeGroup?.id ?? null} />
       </aside>
 
       <main className="main">
-        {activeGroup
-          ? <GroupChat group={activeGroup} model={selectedModel} />
-          : activeSession
-          ? <Chat sessionId={activeSession} model={selectedModel} />
-          : (
-            <div className="empty-state">
-              <div className="empty-icon">⬡</div>
-              <h2>Welcome, {user?.username}</h2>
-              <p>Privacy-first local AI — your conversations never leave this machine.</p>
-              {selectedModel
-                ? <button className="start-btn" onClick={newSession}>Start a chat with {selectedModel}</button>
-                : <p className="hint">Start Ollama and pull a model:<br /><code>ollama pull llama3.2:3b</code></p>
-              }
-            </div>
-          )
-        }
+        {activeSession ? (
+          <Chat
+            key={activeSession.id}
+            session={activeSession}
+            onUpdate={updateSession}
+            onCreditsEarned={onCreditsEarned}
+            temperature={temperature}
+          />
+        ) : (
+          <div className="empty-state">
+            <div className="empty-icon">⬡</div>
+            <h2>Welcome, {username}</h2>
+            <p>Your questions are embedded locally. Only you decide what gets shared.</p>
+            {selectedModel
+              ? <button className="start-btn" onClick={newSession}>Start a chat with {selectedModel}</button>
+              : <p className="hint">Pull a model: <code>ollama pull qwen2.5-coder:14b</code></p>
+            }
+          </div>
+        )}
       </main>
     </div>
   )

--- a/frontend/src/components/AuthPage.tsx
+++ b/frontend/src/components/AuthPage.tsx
@@ -1,9 +1,8 @@
 import { useState } from 'react'
-import { login, register } from '../api/cloud'
 import './AuthPage.css'
 
 interface Props {
-  onAuth: () => void
+  onAuth: (username: string) => void
 }
 
 export default function AuthPage({ onAuth }: Props) {
@@ -19,13 +18,36 @@ export default function AuthPage({ onAuth }: Props) {
     setError('')
     setLoading(true)
     try {
-      if (mode === 'login') {
-        await login(username, password)
-      } else {
-        await register(username, email, password)
-        await login(username, password)
+      const path = mode === 'login' ? '/api/login' : '/api/register'
+      const body: Record<string, string> = { username, password }
+      if (mode === 'register') body.email = email
+
+      const r = await fetch(path, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+      if (!r.ok) {
+        const text = await r.text()
+        throw new Error(text || `${r.status}`)
       }
-      onAuth()
+      const data = await r.json()
+      const user = data.user ?? { username }
+      localStorage.setItem('mm_user', JSON.stringify(user))
+
+      // After register, auto-login
+      if (mode === 'register') {
+        const lr = await fetch('/api/login', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ username, password }),
+        })
+        if (!lr.ok) throw new Error('Registered but login failed')
+        const ld = await lr.json()
+        localStorage.setItem('mm_user', JSON.stringify(ld.user ?? { username }))
+      }
+
+      onAuth(username)
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : 'Something went wrong')
     } finally {
@@ -38,7 +60,7 @@ export default function AuthPage({ onAuth }: Props) {
       <div className="auth-card">
         <div className="auth-logo">⬡</div>
         <h1 className="auth-title">MeshMind</h1>
-        <p className="auth-sub">Privacy-first local AI — your conversations never leave your machine.</p>
+        <p className="auth-sub">Privacy-first local AI with a shared answer marketplace.</p>
 
         <div className="auth-tabs">
           <button className={mode === 'login' ? 'active' : ''} onClick={() => { setMode('login'); setError('') }}>

--- a/frontend/src/components/Chat.css
+++ b/frontend/src/components/Chat.css
@@ -3,15 +3,77 @@
   flex-direction: column;
   height: 100%;
   overflow: hidden;
+  position: relative;
 }
 
+/* ── Toast ─────────────────────────────────────────────────────────────────── */
+.toast {
+  position: absolute;
+  top: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #27224a;
+  border: 1px solid #7c6af7;
+  color: #c4bdff;
+  border-radius: 8px;
+  padding: 8px 18px;
+  font-size: 0.85rem;
+  font-weight: 500;
+  z-index: 100;
+  white-space: nowrap;
+  animation: fadeInDown 0.2s ease;
+}
+@keyframes fadeInDown {
+  from { opacity: 0; transform: translateX(-50%) translateY(-6px); }
+}
+
+/* ── Context fill bar ──────────────────────────────────────────────────────── */
+.ctx-bar-wrap {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 24px 4px;
+  border-bottom: 1px solid #1a1a1a;
+  background: #0f0f0f;
+  flex-shrink: 0;
+}
+.ctx-bar-track {
+  flex: 1;
+  height: 4px;
+  background: #1e1e1e;
+  border-radius: 2px;
+  overflow: hidden;
+}
+.ctx-bar-fill {
+  height: 100%;
+  border-radius: 2px;
+  transition: width 0.4s ease, background 0.4s ease;
+}
+.ctx-bar-label {
+  font-size: 0.68rem;
+  font-weight: 600;
+  white-space: nowrap;
+  min-width: 140px;
+  text-align: right;
+}
+
+/* ── Context warning banner ────────────────────────────────────────────────── */
+.ctx-warning {
+  padding: 6px 24px;
+  font-size: 0.78rem;
+  background: #0f0f0f;
+  border-bottom: 1px solid;
+  line-height: 1.5;
+  flex-shrink: 0;
+}
+
+/* ── Messages ──────────────────────────────────────────────────────────────── */
 .messages {
   flex: 1;
   overflow-y: auto;
   padding: 24px 0;
   display: flex;
   flex-direction: column;
-  gap: 0;
 }
 
 .chat-hint {
@@ -19,50 +81,210 @@
   color: #555;
   font-size: 0.9rem;
   margin-top: 60px;
+  padding: 0 32px;
+  line-height: 1.8;
 }
 
 .message {
-  padding: 20px 32px;
-  line-height: 1.7;
+  padding: 18px 32px;
+  line-height: 1.75;
   font-size: 0.95rem;
 }
-
 .message.assistant {
   background: #161616;
   border-top: 1px solid #1e1e1e;
   border-bottom: 1px solid #1e1e1e;
 }
 
+/* ── Mode badge ────────────────────────────────────────────────────────────── */
+.mode-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  font-size: 0.78rem;
+  font-weight: 600;
+  border-radius: 6px;
+  padding: 5px 10px;
+  margin-bottom: 10px;
+}
+.mode-verbatim { background: #0d2416; border: 1px solid #1a5c35; color: #3dba6c; }
+.mode-repackage { background: #2a2000; border: 1px solid #6b5200; color: #f0b429; }
+.mode-miss { background: #1e0e0e; border: 1px solid #5a1f1f; color: #e05c5c; }
+.mode-meta { font-weight: 400; color: #888; font-size: 0.75rem; }
+.mode-meta strong { color: #aaa; font-weight: 600; }
+
+/* ── Message label ─────────────────────────────────────────────────────────── */
 .message-label {
   font-size: 0.72rem;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.6px;
-  color: #666;
+  color: #555;
   margin-bottom: 8px;
 }
-
 .message.assistant .message-label { color: #7c6af7; }
 
-.message-content {
-  white-space: pre-wrap;
-  word-break: break-word;
+/* ── Attachment badge inside message ───────────────────────────────────────── */
+.msg-attachment-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.78rem;
+  border-radius: 6px;
+  padding: 4px 10px;
+  margin-bottom: 8px;
+  border: 1px solid #2a2a2a;
+  background: #1a1a1a;
+  color: #888;
+}
+.msg-attachment-badge.image { border-color: #3d356e; background: #1c1834; color: #a99cf5; }
+.msg-attachment-badge.pdf   { border-color: #3a2200; background: #1e1200; color: #f0a040; }
+
+/* ── Message content / markdown ────────────────────────────────────────────── */
+.message-content { word-break: break-word; overflow-wrap: anywhere; }
+.message-content p { margin: 0 0 0.75em; }
+.message-content p:last-child { margin-bottom: 0; }
+.message-content h1, .message-content h2, .message-content h3 {
+  font-weight: 700; margin: 1em 0 0.4em; line-height: 1.3;
+}
+.message-content h1 { font-size: 1.3em; }
+.message-content h2 { font-size: 1.15em; }
+.message-content h3 { font-size: 1em; }
+.message-content ul, .message-content ol { padding-left: 1.5em; margin: 0.5em 0; }
+.message-content li { margin: 0.2em 0; }
+.message-content code {
+  background: #1e1e2e; border: 1px solid #2e2e42; border-radius: 4px;
+  padding: 1px 5px; font-size: 0.875em;
+  font-family: 'JetBrains Mono', 'Fira Code', 'Menlo', monospace;
+}
+.message-content pre code { background: none; border: none; padding: 0; }
+.message-content blockquote { border-left: 3px solid #333; padding-left: 12px; color: #888; margin: 0.5em 0; }
+.message-content a { color: #7c6af7; text-decoration: underline; }
+.message-content table { border-collapse: collapse; width: 100%; margin: 0.5em 0; }
+.message-content th, .message-content td { border: 1px solid #2a2a2a; padding: 6px 10px; font-size: 0.9em; }
+.message-content th { background: #1e1e1e; font-weight: 600; }
+.message-content strong { font-weight: 700; color: #f0f0f0; }
+.message-content em { color: #c8c0f0; }
+.message-content .katex { font-size: 1em; }
+.message-content .katex-display { overflow-x: auto; padding: 4px 0; }
+
+/* ── Model switch separator ────────────────────────────────────────────────── */
+.model-separator {
+  display: flex;
+  align-items: center;
+  padding: 6px 32px;
+  gap: 12px;
+}
+.model-separator::before,
+.model-separator::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: #222;
+}
+.model-separator-pill {
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--model-color, #7c6af7);
+  background: color-mix(in srgb, var(--model-color, #7c6af7) 12%, #111);
+  border: 1px solid color-mix(in srgb, var(--model-color, #7c6af7) 30%, transparent);
+  border-radius: 20px;
+  padding: 3px 12px;
+  white-space: nowrap;
+  letter-spacing: 0.3px;
 }
 
-.cursor {
-  display: inline-block;
-  animation: blink 0.8s step-end infinite;
+/* ── Thinking dots ─────────────────────────────────────────────────────────── */
+.thinking-dots { display: inline-flex; gap: 5px; align-items: center; height: 20px; }
+.thinking-dots span {
+  width: 7px; height: 7px; border-radius: 50%;
+  background: #555; animation: pulse 1.2s ease-in-out infinite;
 }
-@keyframes blink { 50% { opacity: 0; } }
+.thinking-dots span:nth-child(2) { animation-delay: 0.2s; }
+.thinking-dots span:nth-child(3) { animation-delay: 0.4s; }
+@keyframes pulse { 0%, 80%, 100% { opacity: 0.3; } 40% { opacity: 1; } }
 
-/* Input */
+/* ── Publish / published ───────────────────────────────────────────────────── */
+.publish-btn {
+  display: inline-flex; align-items: center; gap: 6px;
+  margin-top: 12px; background: none; border: 1px solid #333;
+  color: #888; border-radius: 6px; padding: 6px 14px;
+  font-size: 0.8rem; cursor: pointer;
+  transition: border-color 0.15s, color 0.15s, background 0.15s;
+}
+.publish-btn:hover { border-color: #7c6af7; color: #c4bdff; background: #1c1834; }
+.publish-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.published-badge {
+  display: inline-block; margin-top: 10px; font-size: 0.75rem;
+  color: #3dba6c; border: 1px solid #1a5c35; border-radius: 6px;
+  padding: 3px 10px; background: #0d2416;
+}
+
+/* ── Input area ────────────────────────────────────────────────────────────── */
 .input-area {
   display: flex;
-  gap: 10px;
-  padding: 16px 32px 24px;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px 24px 20px;
   border-top: 1px solid #1e1e1e;
   background: #0f0f0f;
 }
+
+/* Attachment preview strip */
+.attachment-preview {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: #1a1a1a;
+  border: 1px solid #2e2e2e;
+  border-radius: 10px;
+  padding: 8px 12px;
+  font-size: 0.82rem;
+  color: #aaa;
+}
+.attach-thumb {
+  width: 48px;
+  height: 48px;
+  object-fit: cover;
+  border-radius: 6px;
+  border: 1px solid #333;
+  flex-shrink: 0;
+}
+.attach-icon { font-size: 1.4rem; line-height: 1; }
+.attach-name { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.attach-loading { flex: 1; color: #666; font-style: italic; }
+.attach-remove {
+  background: none; border: none; color: #555; font-size: 0.85rem;
+  cursor: pointer; padding: 2px 6px; border-radius: 4px;
+  transition: color 0.15s; flex-shrink: 0;
+}
+.attach-remove:hover { color: #f66; }
+
+/* Input row */
+.input-row {
+  display: flex;
+  align-items: flex-end;
+  gap: 10px;
+}
+
+.attach-btn {
+  background: none;
+  border: 1px solid #2e2e2e;
+  color: #666;
+  border-radius: 10px;
+  width: 44px;
+  height: 44px;
+  font-size: 1.3rem;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: border-color 0.15s, color 0.15s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.attach-btn:hover { border-color: #7c6af7; color: #a99cf5; }
+.attach-btn:disabled { opacity: 0.4; cursor: not-allowed; }
 
 .input-box {
   flex: 1;
@@ -91,7 +313,7 @@
   height: 44px;
   font-size: 1.1rem;
   cursor: pointer;
-  align-self: flex-end;
+  flex-shrink: 0;
   transition: background 0.15s;
   display: flex;
   align-items: center;
@@ -99,3 +321,13 @@
 }
 .send-btn:hover { background: #6a58e5; }
 .send-btn:disabled { background: #333; cursor: not-allowed; }
+
+/* ── Token stats per message ───────────────────────────────────────────────── */
+.token-stats {
+  display: flex;
+  gap: 10px;
+  margin-top: 8px;
+  font-size: 0.68rem;
+  color: #3a3a3a;
+}
+.token-stats span { white-space: nowrap; }

--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -1,114 +1,531 @@
 import { useState, useEffect, useRef } from 'react'
+import ReactMarkdown from 'react-markdown'
+import remarkMath from 'remark-math'
+import rehypeKatex from 'rehype-katex'
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
+import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism'
+import type { LocalMessage, LocalSession } from '../App'
+import { modelColor, contextWindowSize, ctxFillColor, ctxWarning } from '../utils/models'
 import './Chat.css'
 
-interface Message {
-  role: 'user' | 'assistant'
-  content: string
-  from_peer?: boolean
-}
-
 interface Props {
-  sessionId: string
-  model: string
+  session: LocalSession
+  onUpdate: (updated: LocalSession) => void
+  onCreditsEarned: (n: number) => void
+  temperature: number
 }
 
-export default function Chat({ sessionId, model }: Props) {
-  const [messages, setMessages] = useState<Message[]>([])
+interface Attachment {
+  type: 'image' | 'pdf'
+  name: string
+  previewUrl?: string   // image thumbnail (object URL, not persisted)
+  b64?: string          // image base64 for sending
+  text?: string         // PDF extracted text
+}
+
+const MODE_LABEL: Record<string, string> = {
+  verbatim: '✓ Cached answer',
+  repackage: '↻ Repackaged',
+  miss: '✗ Fresh inference',
+}
+
+function Markdown({ content }: { content: string }) {
+  return (
+    <ReactMarkdown
+      remarkPlugins={[remarkMath]}
+      rehypePlugins={[rehypeKatex]}
+      components={{
+        code({ className, children, ...rest }) {
+          const match = /language-(\w+)/.exec(className ?? '')
+          if (match) {
+            return (
+              <SyntaxHighlighter
+                style={oneDark}
+                language={match[1]}
+                PreTag="div"
+                customStyle={{ borderRadius: '8px', fontSize: '0.875rem', margin: '8px 0' }}
+              >
+                {String(children).replace(/\n$/, '')}
+              </SyntaxHighlighter>
+            )
+          }
+          return <code className={className} {...rest}>{children}</code>
+        },
+      }}
+    >
+      {content}
+    </ReactMarkdown>
+  )
+}
+
+export default function Chat({ session, onUpdate, onCreditsEarned, temperature }: Props) {
+  // Local message state — updated per-token during streaming, synced to parent on completion
+  const [msgs, setMsgs] = useState<LocalMessage[]>(session.messages)
   const [input, setInput] = useState('')
   const [streaming, setStreaming] = useState(false)
+  const [attachment, setAttachment] = useState<Attachment | null>(null)
+  const [attachLoading, setAttachLoading] = useState(false)
+  const [publishingIdx, setPublishingIdx] = useState<number | null>(null)
+  const [toast, setToast] = useState<string | null>(null)
+
   const bottomRef = useRef<HTMLDivElement>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
 
-  useEffect(() => {
-    setMessages([])
-    fetch(`/api/sessions/${sessionId}/messages`)
-      .then(r => r.json())
-      .then(setMessages)
-      .catch(() => {})
-  }, [sessionId])
+  // Sync messages when switching to a different session
+  useEffect(() => { setMsgs(session.messages) }, [session.id])
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
-  }, [messages])
+  }, [msgs, streaming])
+
+  useEffect(() => {
+    if (!toast) return
+    const t = setTimeout(() => setToast(null), 3000)
+    return () => clearTimeout(t)
+  }, [toast])
+
+  // Clean up image object URLs on unmount to avoid memory leaks
+  useEffect(() => {
+    return () => {
+      if (attachment?.previewUrl) URL.revokeObjectURL(attachment.previewUrl)
+    }
+  }, [attachment])
+
+  // ── File attachment ────────────────────────────────────────────────────────
+
+  const openFilePicker = () => fileInputRef.current?.click()
+
+  const handleFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    e.target.value = ''
+    if (!file) return
+
+    if (file.type.startsWith('image/')) {
+      setAttachLoading(true)
+      const reader = new FileReader()
+      reader.onload = () => {
+        const dataUrl = reader.result as string
+        const b64 = dataUrl.split(',')[1]
+        setAttachment({
+          type: 'image',
+          name: file.name,
+          previewUrl: URL.createObjectURL(file),
+          b64,
+        })
+        setAttachLoading(false)
+      }
+      reader.readAsDataURL(file)
+    } else if (file.type === 'application/pdf') {
+      setAttachLoading(true)
+      try {
+        const form = new FormData()
+        form.append('file', file)
+        const r = await fetch('/api/parse/pdf', { method: 'POST', body: form })
+        if (!r.ok) throw new Error(await r.text())
+        const data = await r.json()
+        setAttachment({ type: 'pdf', name: file.name, text: data.text })
+      } catch (err) {
+        setToast(`PDF error: ${err instanceof Error ? err.message : 'failed'}`)
+      } finally {
+        setAttachLoading(false)
+      }
+    } else {
+      setToast('Only PNG, JPEG, and PDF files are supported.')
+    }
+  }
+
+  const removeAttachment = () => {
+    if (attachment?.previewUrl) URL.revokeObjectURL(attachment.previewUrl)
+    setAttachment(null)
+  }
+
+  // ── Send ──────────────────────────────────────────────────────────────────
 
   const send = async () => {
     const text = input.trim()
-    if (!text || streaming) return
+    if ((!text && !attachment) || streaming) return
     setInput('')
+    resetTextareaHeight()
 
-    const userMsg: Message = { role: 'user', content: text }
-    setMessages(prev => [...prev, userMsg])
+    // Build the prompt and user message
+    let prompt = text
+    let imageB64: string | undefined
+    const att = attachment
+    setAttachment(null)
+
+    const userMsg: LocalMessage = {
+      role: 'user',
+      content: text || `[${att?.name}]`,
+      attachmentType: att?.type,
+      attachmentName: att?.name,
+    }
+
+    if (att?.type === 'image' && att.b64) {
+      imageB64 = att.b64
+      prompt = text || 'Describe this image.'
+    } else if (att?.type === 'pdf' && att.text) {
+      prompt = `[PDF: ${att.name}]\n\n${att.text}\n\n---\n\n${text || 'Please summarize this document.'}`
+    }
+
+    // Build conversation history from prior messages (exclude system separators)
+    // First message → no history → marketplace lookup eligible
+    // Subsequent messages → pass history → model gets full context
+    const history = msgs
+      .filter(m => m.role === 'user' || m.role === 'assistant')
+      .map(m => ({ role: m.role as 'user' | 'assistant', content: m.content }))
+
+    const isFirst = history.length === 0
+    const newTitle = isFirst
+      ? (text || att?.name || 'New chat').slice(0, 40)
+      : session.title
+
+    // Optimistically add user + empty assistant placeholder
+    const placeholder: LocalMessage = { role: 'assistant', content: '', model: session.model }
+    const withUser = [...msgs, userMsg, placeholder]
+    setMsgs(withUser)
     setStreaming(true)
 
-    const assistantMsg: Message = { role: 'assistant', content: '' }
-    setMessages(prev => [...prev, assistantMsg])
+    // Sync title change to parent immediately
+    if (isFirst) onUpdate({ ...session, title: newTitle, messages: [...msgs, userMsg] })
 
     try {
-      const res = await fetch(`/api/sessions/${sessionId}/chat`, {
+      const r = await fetch('/api/ask/stream', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ content: text, model }),
+        body: JSON.stringify({
+          prompt,
+          model: session.model,
+          image_b64: imageB64,
+          history: history.length > 0 ? history : undefined,
+          temperature,
+        }),
       })
-
-      if (!res.ok) {
-        const err = await res.json().catch(() => ({ detail: res.statusText }))
-        throw new Error(err.detail || res.statusText)
+      if (!r.ok) {
+        const err = await r.json().catch(() => ({ detail: r.statusText }))
+        throw new Error(err.detail || r.statusText)
       }
 
-      const data = await res.json()
-      setMessages(prev => {
-        const updated = [...prev]
-        updated[updated.length - 1] = { role: 'assistant', content: data.content }
-        return updated
-      })
+      const reader = r.body!.getReader()
+      const decoder = new TextDecoder()
+      let buf = ''
+      let accumulated = ''
+      let finalMeta: Partial<LocalMessage> = { mode: 'miss' }
+
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        buf += decoder.decode(value, { stream: true })
+
+        const lines = buf.split('\n')
+        buf = lines.pop() ?? ''
+
+        for (const line of lines) {
+          if (!line.startsWith('data: ')) continue
+          try {
+            const payload = JSON.parse(line.slice(6))
+            if (payload.chunk) {
+              accumulated += payload.chunk
+              // Update the last message (the placeholder) in real-time
+              setMsgs(prev => {
+                const updated = [...prev]
+                updated[updated.length - 1] = { ...updated[updated.length - 1], content: accumulated }
+                return updated
+              })
+            }
+            if (payload.done) {
+              finalMeta = {
+                mode: payload.mode,
+                source_author: payload.source_author,
+                similarity: payload.similarity,
+                source_entry_id: payload.source_entry_id,
+                embedding: payload.embedding,
+                tokensIn: payload.tokens_in,
+                tokensOut: payload.tokens_out,
+                toksPerSec: payload.toks_per_sec ?? null,
+              }
+            }
+          } catch { /* malformed SSE line — skip */ }
+        }
+      }
+
+      // Finalise the assistant message with metadata + which model generated it
+      const assistantMsg: LocalMessage = {
+        role: 'assistant',
+        content: accumulated,
+        model: session.model,
+        published: false,
+        ...finalMeta,
+      }
+      const finalMsgs = [...msgs, userMsg, assistantMsg]
+      setMsgs(finalMsgs)
+      onUpdate({ ...session, title: newTitle, messages: finalMsgs })
+
     } catch (e) {
-      setMessages(prev => {
-        const updated = [...prev]
-        updated[updated.length - 1] = { role: 'assistant', content: '⚠ Connection error.' }
-        return updated
-      })
+      const errMsg: LocalMessage = { role: 'assistant', content: `⚠ ${e instanceof Error ? e.message : 'Connection error'}`, mode: 'miss' }
+      const finalMsgs = [...msgs, userMsg, errMsg]
+      setMsgs(finalMsgs)
+      onUpdate({ ...session, title: newTitle, messages: finalMsgs })
     } finally {
       setStreaming(false)
       textareaRef.current?.focus()
     }
   }
 
-  const onKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
-      e.preventDefault()
-      send()
+  // ── Publish ───────────────────────────────────────────────────────────────
+
+  const publish = async (msgIdx: number) => {
+    const msg = msgs[msgIdx]
+    const userMsg = msgs[msgIdx - 1]
+    if (!msg || msg.published || !userMsg || userMsg.role !== 'user') return
+
+    setPublishingIdx(msgIdx)
+    try {
+      const r = await fetch('/api/publish', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          prompt: userMsg.content,
+          response: msg.content,
+          model_used: session.model,
+          embedding: msg.embedding ?? [],
+          tags: [],
+        }),
+      })
+      if (!r.ok) throw new Error(await r.text())
+      const data = await r.json()
+      const earned: number = data.creditsEarned ?? 5
+      const updated = msgs.map((m, i) => i === msgIdx ? { ...m, published: true } : m)
+      setMsgs(updated)
+      onUpdate({ ...session, messages: updated })
+      onCreditsEarned(earned)
+      setToast(`Published! +${earned} credits`)
+    } catch (e) {
+      setToast(`Publish failed: ${e instanceof Error ? e.message : 'error'}`)
+    } finally {
+      setPublishingIdx(null)
     }
   }
 
+  // ── Input helpers ─────────────────────────────────────────────────────────
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); send() }
+  }
+
+  const resetTextareaHeight = () => {
+    if (textareaRef.current) textareaRef.current.style.height = 'auto'
+  }
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setInput(e.target.value)
+    e.target.style.height = 'auto'
+    e.target.style.height = Math.min(e.target.scrollHeight, 200) + 'px'
+  }
+
+  // ── Context fill derived from last assistant message with token data ─────────
+  const lastAssistant = [...msgs].reverse().find(m => m.role === 'assistant' && m.tokensIn !== undefined)
+  const ctxWindowSize = contextWindowSize(session.model)
+  const ctxUsed = lastAssistant ? (lastAssistant.tokensIn ?? 0) + (lastAssistant.tokensOut ?? 0) : 0
+  const ctxPct = ctxUsed > 0 ? Math.min(ctxUsed / ctxWindowSize, 1) : 0
+  const ctxWarn = ctxWarning(ctxPct)
+
+  // ── Render ────────────────────────────────────────────────────────────────
+
   return (
     <div className="chat">
-      <div className="messages">
-        {messages.length === 0 && (
-          <div className="chat-hint">Send a message to start chatting with <strong>{model}</strong></div>
-        )}
-        {messages.map((m, i) => (
-          <div key={i} className={`message ${m.role}`}>
-            <div className="message-label">{m.role === 'user' ? 'You' : model}</div>
-            <div className="message-content">{m.content || (streaming ? <span className="cursor">▍</span> : '')}</div>
+      {toast && <div className="toast">{toast}</div>}
+
+      {/* Context fill bar — only shown once we have token data */}
+      {ctxUsed > 0 && (
+        <div className="ctx-bar-wrap">
+          <div className="ctx-bar-track">
+            <div
+              className="ctx-bar-fill"
+              style={{ width: `${ctxPct * 100}%`, background: ctxFillColor(ctxPct) }}
+            />
           </div>
-        ))}
+          <span className="ctx-bar-label" style={{ color: ctxFillColor(ctxPct) }}>
+            {Math.round(ctxPct * 100)}% ctx · {ctxUsed.toLocaleString()}/{ctxWindowSize.toLocaleString()} tok
+          </span>
+        </div>
+      )}
+      {ctxWarn && (
+        <div className="ctx-warning" style={{ borderColor: ctxFillColor(ctxPct), color: ctxFillColor(ctxPct) }}>
+          {ctxWarn}
+        </div>
+      )}
+
+      <div className="messages">
+        {msgs.length === 0 && !streaming && (
+          <div className="chat-hint">
+            Ask anything — embed locally, search the marketplace, get an answer.
+            <br />Attach an image or PDF with the paperclip.
+          </div>
+        )}
+
+        {msgs.map((m, i) => {
+          // ── System separator (model switch) ────────────────────────────────
+          if (m.role === 'system') {
+            return (
+              <div key={i} className="model-separator">
+                <span
+                  className="model-separator-pill"
+                  style={{ '--model-color': modelColor(m.model ?? '') } as React.CSSProperties}
+                >
+                  {m.content}
+                </span>
+              </div>
+            )
+          }
+
+          const msgModel = m.model ?? session.model
+          const color = modelColor(msgModel)
+
+          return (
+          <div key={i} className={`message ${m.role}`}>
+            {/* Mode badge on assistant messages */}
+            {m.role === 'assistant' && m.mode && (
+              <div className={`mode-badge mode-${m.mode}`}>
+                <span>{MODE_LABEL[m.mode]}</span>
+                {m.source_author && m.similarity !== undefined && (
+                  <span className="mode-meta">
+                    from <strong>{m.source_author}</strong>
+                    {' · '}{(m.similarity * 100).toFixed(1)}% match
+                  </span>
+                )}
+              </div>
+            )}
+
+            <div
+              className="message-label"
+              style={m.role === 'assistant' ? { color } : undefined}
+            >
+              {m.role === 'user' ? 'You' : msgModel}
+            </div>
+
+            {/* Attachment badge on user messages */}
+            {m.role === 'user' && m.attachmentName && (
+              <div className={`msg-attachment-badge ${m.attachmentType}`}>
+                {m.attachmentType === 'image' ? '🖼' : '📄'} {m.attachmentName}
+              </div>
+            )}
+
+            <div className="message-content">
+              {m.role === 'assistant'
+                ? <Markdown content={m.content} />
+                : <span>{m.content}</span>
+              }
+            </div>
+
+            {/* Publish / published */}
+            {m.role === 'assistant' && m.mode === 'miss' && !m.published && m.embedding?.length && (
+              <button
+                className="publish-btn"
+                onClick={() => publish(i)}
+                disabled={publishingIdx === i}
+              >
+                {publishingIdx === i ? 'Publishing…' : '↑ Publish to marketplace (+5 credits)'}
+              </button>
+            )}
+            {m.role === 'assistant' && m.published && (
+              <span className="published-badge">✓ Published</span>
+            )}
+
+            {/* Token stats */}
+            {m.role === 'assistant' && m.tokensOut !== undefined && m.tokensOut > 0 && (
+              <div className="token-stats">
+                <span>{m.tokensOut} out</span>
+                {m.tokensIn !== undefined && m.tokensIn > 0 && <span>{m.tokensIn} in</span>}
+                {m.toksPerSec != null && <span>{m.toksPerSec} tok/s</span>}
+              </div>
+            )}
+          </div>
+          )
+        })}
+
+        {/* Streaming in-progress indicator (shown only while waiting for first token) */}
+        {streaming && msgs[msgs.length - 1]?.content === '' && (
+          <div className="message assistant">
+            <div
+              className="message-label"
+              style={{ color: modelColor(session.model) }}
+            >
+              {session.model}
+            </div>
+            <div className="message-content">
+              <span className="thinking-dots"><span /><span /><span /></span>
+            </div>
+          </div>
+        )}
+
         <div ref={bottomRef} />
       </div>
 
+      {/* ── Input area ── */}
       <div className="input-area">
-        <textarea
-          ref={textareaRef}
-          className="input-box"
-          value={input}
-          onChange={e => setInput(e.target.value)}
-          onKeyDown={onKeyDown}
-          placeholder="Message… (Enter to send, Shift+Enter for newline)"
-          rows={1}
-          disabled={streaming}
-        />
-        <button className="send-btn" onClick={send} disabled={streaming || !input.trim()}>
-          {streaming ? '◼' : '↑'}
-        </button>
+        {/* Attachment preview */}
+        {(attachment || attachLoading) && (
+          <div className="attachment-preview">
+            {attachLoading ? (
+              <span className="attach-loading">Parsing…</span>
+            ) : attachment?.type === 'image' && attachment.previewUrl ? (
+              <>
+                <img src={attachment.previewUrl} alt={attachment.name} className="attach-thumb" />
+                <span className="attach-name">{attachment.name}</span>
+                <button className="attach-remove" onClick={removeAttachment}>✕</button>
+              </>
+            ) : (
+              <>
+                <span className="attach-icon">📄</span>
+                <span className="attach-name">{attachment?.name}</span>
+                <button className="attach-remove" onClick={removeAttachment}>✕</button>
+              </>
+            )}
+          </div>
+        )}
+
+        <div className="input-row">
+          <button
+            className="attach-btn"
+            onClick={openFilePicker}
+            disabled={streaming || attachLoading}
+            title="Attach image (PNG/JPEG) or PDF"
+          >
+            ⊕
+          </button>
+
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/png,image/jpeg,image/jpg,application/pdf"
+            style={{ display: 'none' }}
+            onChange={handleFile}
+          />
+
+          <textarea
+            ref={textareaRef}
+            className="input-box"
+            value={input}
+            onChange={handleInputChange}
+            onKeyDown={onKeyDown}
+            placeholder={
+              attachment
+                ? `Add a message for ${attachment.name}… (or press Enter)`
+                : 'Ask anything… (Enter to send, Shift+Enter for newline)'
+            }
+            rows={1}
+            disabled={streaming}
+          />
+
+          <button
+            className="send-btn"
+            onClick={send}
+            disabled={streaming || (!input.trim() && !attachment)}
+          >
+            {streaming ? '◼' : '↑'}
+          </button>
+        </div>
       </div>
     </div>
   )

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,10 +1,10 @@
-import React from 'react'
-import ReactDOM from 'react-dom/client'
-import App from './App'
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
 import './index.css'
+import App from './App'
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
     <App />
-  </React.StrictMode>,
+  </StrictMode>,
 )

--- a/frontend/src/utils/models.ts
+++ b/frontend/src/utils/models.ts
@@ -1,0 +1,129 @@
+// ── Model color palette ────────────────────────────────────────────────────────
+const COLOR_PALETTE = [
+  '#7c6af7', // purple  (default / qwen)
+  '#4bc8f0', // cyan    (phi / gemma)
+  '#3dba6c', // green   (llama)
+  '#f0b429', // amber   (mistral)
+  '#e05c7a', // rose    (deepseek)
+  '#f07c4b', // orange  (command-r)
+  '#a78bfa', // violet  (llava)
+  '#60a5fa', // blue    (general)
+]
+
+export function modelColor(name: string): string {
+  let h = 0
+  for (let i = 0; i < name.length; i++) h = (h * 31 + name.charCodeAt(i)) & 0xffffffff
+  return COLOR_PALETTE[Math.abs(h) % COLOR_PALETTE.length]
+}
+
+// ── Capability tags ────────────────────────────────────────────────────────────
+export type ModelTag = 'CODE' | 'VISION' | 'FAST' | 'REASON' | 'MATH' | 'GENERAL' | 'EMBED'
+
+const TAG_RULES: Array<{ match: string; tags: ModelTag[] }> = [
+  { match: 'qwen2.5-coder',  tags: ['CODE', 'REASON'] },
+  { match: 'qwen2.5vl',      tags: ['VISION', 'REASON'] },
+  { match: 'deepseek-coder', tags: ['CODE'] },
+  { match: 'starcoder',      tags: ['CODE'] },
+  { match: 'codellama',      tags: ['CODE'] },
+  { match: 'llava',          tags: ['VISION', 'REASON'] },
+  { match: 'minicpm-v',      tags: ['VISION', 'FAST'] },
+  { match: 'moondream',      tags: ['VISION', 'FAST'] },
+  { match: 'phi',            tags: ['REASON', 'FAST'] },
+  { match: 'phi3',           tags: ['REASON', 'FAST'] },
+  { match: 'phi4',           tags: ['REASON', 'MATH'] },
+  { match: 'gemma3',         tags: ['GENERAL', 'REASON'] },
+  { match: 'gemma2',         tags: ['GENERAL', 'FAST'] },
+  { match: 'llama3.2:1b',   tags: ['FAST'] },
+  { match: 'llama3.2:3b',   tags: ['FAST', 'GENERAL'] },
+  { match: 'llama3.3',       tags: ['GENERAL', 'REASON'] },
+  { match: 'llama3.1',       tags: ['GENERAL', 'REASON'] },
+  { match: 'mistral',        tags: ['GENERAL', 'FAST'] },
+  { match: 'qwen2.5:',       tags: ['GENERAL', 'MATH'] },
+  { match: 'deepseek-r1',    tags: ['REASON', 'MATH'] },
+  { match: 'nomic-embed',    tags: ['EMBED'] },
+]
+
+export function modelTags(name: string): ModelTag[] {
+  const lower = name.toLowerCase()
+  for (const rule of TAG_RULES) {
+    if (lower.includes(rule.match)) return rule.tags
+  }
+  return ['GENERAL']
+}
+
+export const TAG_COLORS: Record<ModelTag, string> = {
+  CODE:    '#4bc8f0',
+  VISION:  '#a78bfa',
+  FAST:    '#3dba6c',
+  REASON:  '#f0b429',
+  MATH:    '#f07c4b',
+  GENERAL: '#888',
+  EMBED:   '#555',
+}
+
+// ── Context window sizes ───────────────────────────────────────────────────────
+// Ollama defaults to 2048 — we override to 8192 in all requests.
+// These are the ACTUAL model limits for the progress bar ceiling.
+const CTX_RULES: Array<{ match: string; ctx: number }> = [
+  { match: 'llama3.2:1b',      ctx: 131072 },
+  { match: 'llama3.2:3b',      ctx: 131072 },
+  { match: 'llama3.1',         ctx: 131072 },
+  { match: 'llama3.3',         ctx: 131072 },
+  { match: 'qwen2.5-coder:7b', ctx: 32768 },
+  { match: 'qwen2.5-coder:14b',ctx: 32768 },
+  { match: 'qwen2.5-coder:32b',ctx: 16384 },
+  { match: 'qwen2.5:',         ctx: 32768 },
+  { match: 'phi3',             ctx: 131072 },
+  { match: 'phi4',             ctx: 16384 },
+  { match: 'gemma3',           ctx: 131072 },
+  { match: 'gemma2',           ctx: 8192 },
+  { match: 'mistral',          ctx: 32768 },
+  { match: 'llava',            ctx: 4096 },
+  { match: 'deepseek-r1',      ctx: 131072 },
+  { match: 'deepseek-coder',   ctx: 16384 },
+]
+
+// The num_ctx we actually request from Ollama — keep this at or below the model limit.
+export const REQUEST_NUM_CTX = 8192
+
+export function contextWindowSize(name: string): number {
+  const lower = name.toLowerCase()
+  for (const rule of CTX_RULES) {
+    if (lower.includes(rule.match)) return Math.min(rule.ctx, REQUEST_NUM_CTX)
+  }
+  return REQUEST_NUM_CTX
+}
+
+// ── Temperature labels ─────────────────────────────────────────────────────────
+export function tempLabel(t: number): string {
+  if (t <= 0.05) return 'Deterministic'
+  if (t <= 0.35) return 'Precise'
+  if (t <= 0.65) return 'Balanced'
+  if (t <= 0.95) return 'Creative'
+  if (t <= 1.30) return 'Expressive'
+  if (t <= 1.70) return 'Experimental'
+  return 'Chaotic'
+}
+
+export function tempColor(t: number): string {
+  if (t <= 0.35) return '#4bc8f0'  // cool blue
+  if (t <= 0.65) return '#3dba6c'  // green
+  if (t <= 0.95) return '#f0b429'  // amber
+  if (t <= 1.30) return '#f07c4b'  // orange
+  return '#e05c7a'                  // red
+}
+
+// ── Context fill severity ──────────────────────────────────────────────────────
+export function ctxFillColor(pct: number): string {
+  if (pct < 0.55) return '#3dba6c'
+  if (pct < 0.75) return '#f0b429'
+  if (pct < 0.90) return '#f07c4b'
+  return '#e05c7a'
+}
+
+export function ctxWarning(pct: number): string | null {
+  if (pct >= 0.90) return 'Context nearly full — quality degrades here with local models. Start a new chat or the model may repeat itself.'
+  if (pct >= 0.75) return 'Context filling up — responses may slow down and lose coherence.'
+  if (pct >= 0.55) return 'Past halfway — keep an eye on context if this is a long reasoning task.'
+  return null
+}

--- a/openclaw/app/market_client.py
+++ b/openclaw/app/market_client.py
@@ -1,0 +1,77 @@
+"""
+Cloud marketplace client. Talks to the Spring Boot backend.
+Drop-in module — can be imported by the existing OpenClaw app or used standalone.
+"""
+from __future__ import annotations
+
+import httpx
+from typing import Optional
+
+
+class MarketClient:
+    def __init__(self, base_url: str = "http://localhost:8080"):
+        self.base_url = base_url.rstrip("/")
+        self.token: Optional[str] = None
+        self.username: Optional[str] = None
+
+    def _headers(self) -> dict:
+        h = {"Content-Type": "application/json"}
+        if self.token:
+            h["Authorization"] = f"Bearer {self.token}"
+        return h
+
+    async def register(self, username: str, email: str, password: str) -> dict:
+        async with httpx.AsyncClient(timeout=10) as c:
+            r = await c.post(f"{self.base_url}/api/auth/register", headers=self._headers(),
+                             json={"username": username, "email": email, "password": password})
+            r.raise_for_status()
+            data = r.json()
+            self.token = data["token"]
+            self.username = data["user"]["username"]
+            return data
+
+    async def login(self, username: str, password: str) -> dict:
+        async with httpx.AsyncClient(timeout=10) as c:
+            r = await c.post(f"{self.base_url}/api/auth/login", headers=self._headers(),
+                             json={"username": username, "password": password})
+            r.raise_for_status()
+            data = r.json()
+            self.token = data["token"]
+            self.username = data["user"]["username"]
+            return data
+
+    async def me(self) -> dict:
+        async with httpx.AsyncClient(timeout=10) as c:
+            r = await c.get(f"{self.base_url}/api/users/me", headers=self._headers())
+            r.raise_for_status()
+            return r.json()
+
+    async def search(self, embedding: list[float], k: int = 3) -> list[dict]:
+        async with httpx.AsyncClient(timeout=15) as c:
+            r = await c.post(f"{self.base_url}/api/market/search", headers=self._headers(),
+                             json={"embedding": embedding, "k": k})
+            r.raise_for_status()
+            return r.json()["results"]
+
+    async def publish(self, prompt: str, response: str, model_used: str,
+                      embedding: list[float], tags: Optional[list[str]] = None) -> dict:
+        async with httpx.AsyncClient(timeout=15) as c:
+            r = await c.post(f"{self.base_url}/api/market/publish", headers=self._headers(),
+                             json={"prompt": prompt, "response": response,
+                                   "modelUsed": model_used, "embedding": embedding,
+                                   "tags": tags or []})
+            r.raise_for_status()
+            return r.json()
+
+    async def consume(self, entry_id: str) -> dict:
+        async with httpx.AsyncClient(timeout=10) as c:
+            r = await c.post(f"{self.base_url}/api/market/consume", headers=self._headers(),
+                             json={"entryId": entry_id})
+            r.raise_for_status()
+            return r.json()
+
+    async def mine(self) -> list[dict]:
+        async with httpx.AsyncClient(timeout=10) as c:
+            r = await c.get(f"{self.base_url}/api/market/mine", headers=self._headers())
+            r.raise_for_status()
+            return r.json()["entries"]

--- a/openclaw/app/ollama_client.py
+++ b/openclaw/app/ollama_client.py
@@ -1,0 +1,118 @@
+"""Minimal Ollama client: embeddings + chat."""
+from __future__ import annotations
+
+import os
+import httpx
+from typing import AsyncIterator
+import json
+
+
+OLLAMA_URL = os.environ.get("OLLAMA_URL", "http://localhost:11434")
+EMBED_MODEL = os.environ.get("MESHMIND_EMBED_MODEL", "nomic-embed-text")   # 768 dims
+DEFAULT_CHAT_MODEL = os.environ.get("MESHMIND_CHAT_MODEL", "qwen2.5-coder:14b")
+
+
+async def embed(text: str, model: str = EMBED_MODEL) -> list[float]:
+    """Return an embedding vector for text. Requires `ollama pull nomic-embed-text`."""
+    async with httpx.AsyncClient(timeout=30) as c:
+        r = await c.post(f"{OLLAMA_URL}/api/embeddings",
+                         json={"model": model, "prompt": text})
+        r.raise_for_status()
+        return r.json()["embedding"]
+
+
+async def chat(prompt: str, model: str = DEFAULT_CHAT_MODEL,
+               system: str | None = None) -> str:
+    """Non-streaming chat for simplicity. Returns full response text."""
+    messages = []
+    if system:
+        messages.append({"role": "system", "content": system})
+    messages.append({"role": "user", "content": prompt})
+    async with httpx.AsyncClient(timeout=120) as c:
+        r = await c.post(f"{OLLAMA_URL}/api/chat",
+                         json={"model": model, "messages": messages, "stream": False})
+        r.raise_for_status()
+        return r.json()["message"]["content"]
+
+
+VISION_MODEL = os.environ.get("MESHMIND_VISION_MODEL", "llava:13b")
+
+
+async def chat_stream(prompt: str, model: str = DEFAULT_CHAT_MODEL,
+                      system: str | None = None) -> AsyncIterator[str]:
+    """Streaming chat. Yields token chunks."""
+    messages = []
+    if system:
+        messages.append({"role": "system", "content": system})
+    messages.append({"role": "user", "content": prompt})
+    async with httpx.AsyncClient(timeout=None) as c:
+        async with c.stream("POST", f"{OLLAMA_URL}/api/chat",
+                            json={"model": model, "messages": messages, "stream": True}) as r:
+            async for line in r.aiter_lines():
+                if not line:
+                    continue
+                obj = json.loads(line)
+                if obj.get("done"):
+                    break
+                chunk = obj.get("message", {}).get("content", "")
+                if chunk:
+                    yield chunk
+
+
+DEFAULT_NUM_CTX = int(os.environ.get("MESHMIND_NUM_CTX", "8192"))
+DEFAULT_TEMPERATURE = float(os.environ.get("MESHMIND_TEMPERATURE", "0.7"))
+
+
+async def chat_stream_messages(
+    messages: list[dict],
+    model: str = DEFAULT_CHAT_MODEL,
+    temperature: float = DEFAULT_TEMPERATURE,
+    num_ctx: int = DEFAULT_NUM_CTX,
+    out_meta: dict | None = None,
+) -> AsyncIterator[str]:
+    """Streaming multi-turn chat from a pre-built messages array.
+    Each dict must have 'role' and 'content'; vision messages may include 'images'.
+    Pass ``out_meta={}`` to receive token counts (eval_count, prompt_eval_count,
+    eval_duration_ns) after the generator exhausts.
+    """
+    async with httpx.AsyncClient(timeout=None) as c:
+        async with c.stream(
+            "POST", f"{OLLAMA_URL}/api/chat",
+            json={
+                "model": model,
+                "messages": messages,
+                "stream": True,
+                "options": {"temperature": temperature, "num_ctx": num_ctx},
+            },
+        ) as r:
+            async for line in r.aiter_lines():
+                if not line:
+                    continue
+                obj = json.loads(line)
+                if obj.get("done"):
+                    if out_meta is not None:
+                        out_meta["eval_count"]        = obj.get("eval_count", 0)
+                        out_meta["prompt_eval_count"] = obj.get("prompt_eval_count", 0)
+                        out_meta["eval_duration_ns"]  = obj.get("eval_duration", 0)
+                    break
+                chunk = obj.get("message", {}).get("content", "")
+                if chunk:
+                    yield chunk
+
+
+async def chat_vision_stream(prompt: str, image_b64: str,
+                             model: str = VISION_MODEL) -> AsyncIterator[str]:
+    """Streaming vision chat. Sends a base64-encoded image alongside the prompt."""
+    messages = [{"role": "user", "content": prompt, "images": [image_b64]}]
+    async with httpx.AsyncClient(timeout=None) as c:
+        async with c.stream("POST", f"{OLLAMA_URL}/api/chat",
+                            json={"model": model, "messages": messages, "stream": True}) as r:
+            async for line in r.aiter_lines():
+                if not line:
+                    continue
+                obj = json.loads(line)
+                if obj.get("done"):
+                    break
+                chunk = obj.get("message", {}).get("content", "")
+                if chunk:
+                    yield chunk

--- a/openclaw/app/server.py
+++ b/openclaw/app/server.py
@@ -1,18 +1,33 @@
-from fastapi import FastAPI
+"""
+MeshMind local node — FastAPI service that wraps Ollama and talks to the
+cloud marketplace. This is the demo-able slice of the marketplace flow:
+
+  user query
+      → embed locally via Ollama
+      → search cloud marketplace
+      → if hit (verbatim): return cached answer
+      → if partial (repackage): ask local Ollama to adapt cached answer (few tokens)
+      → if miss: full local inference
+      → offer to publish
+
+Run: uvicorn app.server:app --reload --port 8000
+"""
+from __future__ import annotations
+
+from fastapi import FastAPI, HTTPException, UploadFile, File
 from fastapi.middleware.cors import CORSMiddleware
-from contextlib import asynccontextmanager
+from fastapi.responses import HTMLResponse, StreamingResponse
+from pydantic import BaseModel
+from typing import Optional
+import os
+import io
+import json
+import httpx
 
-from app.database import init_db
-from app.routers import chat, models, upload, group
+from app import ollama_client
+from app.market_client import MarketClient
 
-
-@asynccontextmanager
-async def lifespan(app: FastAPI):
-    await init_db()
-    yield
-
-
-app = FastAPI(title="MeshMind OpenClaw", version="0.1.0", lifespan=lifespan)
+app = FastAPI(title="MeshMind Local Node")
 
 app.add_middleware(
     CORSMiddleware,
@@ -21,12 +36,426 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-app.include_router(chat.router, prefix="/api")
-app.include_router(models.router, prefix="/api")
-app.include_router(upload.router, prefix="/api")
-app.include_router(group.router, prefix="/api")
+CLOUD_URL = os.environ.get("MESHMIND_CLOUD", "http://localhost:8080")
+market = MarketClient(CLOUD_URL)
 
 
-@app.get("/health")
-async def health():
-    return {"status": "ok"}
+# ----- auth pass-through -----
+
+class AuthRequest(BaseModel):
+    username: str
+    email: Optional[str] = None
+    password: str
+
+
+@app.post("/api/register")
+async def register(req: AuthRequest):
+    if not req.email:
+        raise HTTPException(400, "email required")
+    try:
+        return await market.register(req.username, req.email, req.password)
+    except Exception as e:
+        raise HTTPException(400, str(e))
+
+
+@app.post("/api/login")
+async def login(req: AuthRequest):
+    try:
+        return await market.login(req.username, req.password)
+    except Exception as e:
+        raise HTTPException(401, str(e))
+
+
+EMBED_ONLY = {"nomic-embed-text", "mxbai-embed-large", "all-minilm", "nomic-embed"}
+
+@app.get("/api/models")
+async def models():
+    """Return list of locally available chat-capable Ollama models."""
+    try:
+        async with httpx.AsyncClient(timeout=5) as c:
+            r = await c.get(f"{ollama_client.OLLAMA_URL}/api/tags")
+            r.raise_for_status()
+            data = r.json()
+            names = [
+                m["name"] for m in data.get("models", [])
+                if not any(e in m["name"].lower() for e in EMBED_ONLY)
+            ]
+            return {"models": names}
+    except Exception:
+        return {"models": []}
+
+
+@app.get("/api/me")
+async def me():
+    if not market.token:
+        raise HTTPException(401, "not logged in")
+    return await market.me()
+
+
+# ----- the core marketplace flow -----
+
+class QueryRequest(BaseModel):
+    prompt: str
+    model: Optional[str] = None
+
+
+@app.post("/api/ask")
+async def ask(req: QueryRequest):
+    """
+    The hero endpoint. Takes a user prompt and decides:
+      - verbatim (similarity >= 0.90): serve cached, 0 inference tokens
+      - repackage (0.70-0.90): adapt cached with minimal local inference
+      - miss (< 0.70): full local inference
+
+    Always returns {mode, response, source_entry_id?, similarity?, embedding}
+    so the client can decide whether to publish.
+    """
+    embedding = await ollama_client.embed(req.prompt)
+    chat_model = req.model or ollama_client.DEFAULT_CHAT_MODEL
+
+    hits = []
+    if market.token:
+        try:
+            hits = await market.search(embedding, k=3)
+        except Exception:
+            hits = []   # cloud offline → fall through to local inference
+
+    top = hits[0] if hits else None
+
+    if top and top["mode"] == "verbatim":
+        # serve the cached answer directly
+        if market.token:
+            try:
+                await market.consume(top["id"])
+            except Exception:
+                pass
+        return {
+            "mode": "verbatim",
+            "response": top["response"],
+            "source_entry_id": top["id"],
+            "source_author": top["author"],
+            "similarity": top["similarity"],
+            "embedding": embedding,
+        }
+
+    if top and top["mode"] == "repackage":
+        # use the cached answer as context, local model adapts it
+        adaptation_prompt = (
+            f"A user asks: {req.prompt}\n\n"
+            f"A similar question was previously answered as follows:\n"
+            f"---\n{top['response']}\n---\n\n"
+            f"Rewrite this answer to address the user's exact question. "
+            f"Be concise — do not repeat information the user didn't ask for."
+        )
+        response = await ollama_client.chat(adaptation_prompt, model=chat_model)
+        if market.token:
+            try:
+                await market.consume(top["id"])
+            except Exception:
+                pass
+        return {
+            "mode": "repackage",
+            "response": response,
+            "source_entry_id": top["id"],
+            "source_author": top["author"],
+            "similarity": top["similarity"],
+            "embedding": embedding,
+        }
+
+    # miss — full local inference
+    response = await ollama_client.chat(req.prompt, model=chat_model)
+    return {
+        "mode": "miss",
+        "response": response,
+        "embedding": embedding,
+    }
+
+
+class PublishRequest(BaseModel):
+    prompt: str
+    response: str
+    model_used: Optional[str] = None
+    embedding: list[float]
+    tags: Optional[list[str]] = None
+
+
+@app.post("/api/publish")
+async def publish(req: PublishRequest):
+    if not market.token:
+        raise HTTPException(401, "not logged in")
+    return await market.publish(req.prompt, req.response,
+                                 req.model_used or ollama_client.DEFAULT_CHAT_MODEL,
+                                 req.embedding, req.tags)
+
+
+@app.get("/api/mine")
+async def mine():
+    if not market.token:
+        raise HTTPException(401, "not logged in")
+    return {"entries": await market.mine()}
+
+
+# ----- streaming ask -----
+
+class HistoryMessage(BaseModel):
+    role: str    # 'user' or 'assistant'
+    content: str
+
+
+class StreamAskRequest(BaseModel):
+    prompt: str
+    model: Optional[str] = None
+    image_b64: Optional[str] = None          # base64 image for vision
+    history: Optional[list[HistoryMessage]] = None  # prior turns for multi-model context
+    temperature: float = 0.7
+
+
+async def _stream_ask(prompt: str, chat_model: str,
+                      image_b64: Optional[str] = None,
+                      history: Optional[list[HistoryMessage]] = None,
+                      temperature: float = 0.7):
+    """SSE generator:
+    - Single-turn (no history): embed → marketplace → verbatim/repackage/miss
+    - Multi-turn (has history): skip marketplace, give model full conversation context
+    - Vision: skip marketplace, route to vision model with image
+    """
+    try:
+        embedding = await ollama_client.embed(prompt)
+    except Exception:
+        embedding = []
+
+    has_history = bool(history)
+
+    # Multi-turn conversations and vision queries bypass the marketplace —
+    # each turn is unique in context so caching doesn't apply.
+    hits = []
+    if market.token and not image_b64 and not has_history:
+        try:
+            hits = await market.search(embedding, k=3)
+        except Exception:
+            pass
+
+    top = hits[0] if hits else None
+
+    # Verbatim cache hit — no inference needed
+    if top and top["mode"] == "verbatim":
+        try:
+            await market.consume(top["id"])
+        except Exception:
+            pass
+        yield f'data: {json.dumps({"chunk": top["response"]})}\n\n'
+        yield f'data: {json.dumps({"done": True, "mode": "verbatim", "source_author": top["author"], "similarity": top["similarity"], "source_entry_id": top["id"], "embedding": embedding})}\n\n'
+        return
+
+    # Repackage — stream the adaptation
+    if top and top["mode"] == "repackage":
+        try:
+            await market.consume(top["id"])
+        except Exception:
+            pass
+        adaptation_prompt = (
+            f"A user asks: {prompt}\n\n"
+            f"A similar question was previously answered as follows:\n"
+            f"---\n{top['response']}\n---\n\n"
+            f"Rewrite this answer to address the user's exact question. "
+            f"Be concise — do not repeat information the user didn't ask for."
+        )
+        async for chunk in ollama_client.chat_stream(adaptation_prompt, model=chat_model):
+            yield f'data: {json.dumps({"chunk": chunk})}\n\n'
+        yield f'data: {json.dumps({"done": True, "mode": "repackage", "source_author": top["author"], "similarity": top["similarity"], "source_entry_id": top["id"], "embedding": embedding})}\n\n'
+        return
+
+    # Miss, multi-turn, or vision — build full messages array and stream
+    messages: list[dict] = []
+
+    if has_history:
+        messages.extend({"role": m.role, "content": m.content} for m in history)
+
+    out_meta: dict = {}
+
+    if image_b64:
+        messages.append({"role": "user", "content": prompt, "images": [image_b64]})
+        async for chunk in ollama_client.chat_stream_messages(
+            messages, model=ollama_client.VISION_MODEL,
+            temperature=temperature, out_meta=out_meta,
+        ):
+            yield f'data: {json.dumps({"chunk": chunk})}\n\n'
+    else:
+        messages.append({"role": "user", "content": prompt})
+        async for chunk in ollama_client.chat_stream_messages(
+            messages, model=chat_model,
+            temperature=temperature, out_meta=out_meta,
+        ):
+            yield f'data: {json.dumps({"chunk": chunk})}\n\n'
+
+    tokens_out = out_meta.get("eval_count", 0)
+    tokens_in  = out_meta.get("prompt_eval_count", 0)
+    dur_ns     = out_meta.get("eval_duration_ns", 0)
+    toks_per_sec = round(tokens_out / (dur_ns / 1e9), 1) if dur_ns > 0 else None
+
+    yield f'data: {json.dumps({"done": True, "mode": "miss", "embedding": embedding, "tokens_in": tokens_in, "tokens_out": tokens_out, "toks_per_sec": toks_per_sec})}\n\n'
+
+
+@app.post("/api/ask/stream")
+async def ask_stream(req: StreamAskRequest):
+    chat_model = req.model or ollama_client.DEFAULT_CHAT_MODEL
+    return StreamingResponse(
+        _stream_ask(req.prompt, chat_model, req.image_b64, req.history, req.temperature),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
+
+
+# ----- PDF parsing -----
+
+@app.post("/api/parse/pdf")
+async def parse_pdf(file: UploadFile = File(...)):
+    """Extract text from an uploaded PDF and return it."""
+    try:
+        from pypdf import PdfReader
+    except ImportError:
+        raise HTTPException(500, "pypdf not installed — run: pip install pypdf")
+    content = await file.read()
+    reader = PdfReader(io.BytesIO(content))
+    pages_text = []
+    for page in reader.pages:
+        text = page.extract_text()
+        if text:
+            pages_text.append(text)
+    return {"text": "\n\n".join(pages_text), "pages": len(reader.pages)}
+
+
+# ----- tiny built-in UI for demo purposes -----
+
+@app.get("/", response_class=HTMLResponse)
+async def index():
+    return HTMLResponse(INDEX_HTML)
+
+
+INDEX_HTML = """<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>MeshMind — Marketplace Demo</title>
+  <style>
+    body { font-family: system-ui, sans-serif; max-width: 780px; margin: 2em auto; padding: 0 1em; color: #111; }
+    .mode-verbatim { background: #d4edda; border-left: 4px solid #28a745; padding: 0.6em; }
+    .mode-repackage { background: #fff3cd; border-left: 4px solid #ffc107; padding: 0.6em; }
+    .mode-miss { background: #f8d7da; border-left: 4px solid #dc3545; padding: 0.6em; }
+    .hint { color: #666; font-size: 0.9em; }
+    textarea { width: 100%; min-height: 80px; font-family: inherit; }
+    input, button { font: inherit; padding: 0.4em 0.8em; }
+    pre { background: #f6f8fa; padding: 0.8em; overflow-x: auto; white-space: pre-wrap; }
+    .row { display: flex; gap: 0.5em; align-items: center; margin: 0.5em 0; }
+    #me { font-size: 0.9em; color: #555; }
+  </style>
+</head>
+<body>
+  <h1>MeshMind <span class="hint">local node</span></h1>
+  <div id="me">Not logged in.</div>
+
+  <details open>
+    <summary>Login / Register</summary>
+    <div class="row">
+      <input id="username" placeholder="username">
+      <input id="email" placeholder="email (register only)">
+      <input id="password" type="password" placeholder="password">
+      <button onclick="doLogin()">Log in</button>
+      <button onclick="doRegister()">Register</button>
+    </div>
+  </details>
+
+  <h2>Ask</h2>
+  <textarea id="prompt" placeholder="What do you want to know?"></textarea>
+  <div class="row">
+    <button onclick="ask()">Ask</button>
+    <span class="hint">local embed → cloud search → best strategy</span>
+  </div>
+
+  <div id="answer"></div>
+
+  <script>
+    let lastAsk = null;
+
+    async function fetchMe() {
+      try {
+        const r = await fetch('/api/me');
+        if (!r.ok) return;
+        const me = await r.json();
+        document.getElementById('me').textContent =
+          `Logged in as ${me.username} — ${me.credits} credits`;
+      } catch {}
+    }
+
+    async function doLogin() {
+      const body = { username: u().value, password: p().value };
+      const r = await fetch('/api/login', { method: 'POST',
+        headers: {'Content-Type':'application/json'}, body: JSON.stringify(body)});
+      if (!r.ok) return alert('login failed');
+      fetchMe();
+    }
+
+    async function doRegister() {
+      const body = { username: u().value, email: document.getElementById('email').value, password: p().value };
+      const r = await fetch('/api/register', { method: 'POST',
+        headers: {'Content-Type':'application/json'}, body: JSON.stringify(body)});
+      if (!r.ok) return alert('register failed: ' + await r.text());
+      fetchMe();
+    }
+
+    async function ask() {
+      const prompt = document.getElementById('prompt').value.trim();
+      if (!prompt) return;
+      const box = document.getElementById('answer');
+      box.innerHTML = '<p class="hint">thinking…</p>';
+      const r = await fetch('/api/ask', { method: 'POST',
+        headers: {'Content-Type':'application/json'}, body: JSON.stringify({ prompt })});
+      if (!r.ok) { box.innerHTML = '<p>error: ' + await r.text() + '</p>'; return; }
+      const data = await r.json();
+      lastAsk = { prompt, ...data };
+      render(data);
+      fetchMe();
+    }
+
+    function render(data) {
+      const box = document.getElementById('answer');
+      let badge = '';
+      if (data.mode === 'verbatim') {
+        badge = `<div class="mode-verbatim">✓ Cached answer from <b>${data.source_author}</b>
+          (similarity ${data.similarity.toFixed(3)}) — 0 inference tokens.</div>`;
+      } else if (data.mode === 'repackage') {
+        badge = `<div class="mode-repackage">↻ Repackaged from <b>${data.source_author}</b>
+          (similarity ${data.similarity.toFixed(3)}) — minimal inference.</div>`;
+      } else {
+        badge = `<div class="mode-miss">✗ No cache hit — full local inference.</div>`;
+      }
+      let publishBtn = '';
+      if (data.mode === 'miss') {
+        publishBtn = `<button onclick="publish()">Publish to marketplace (+5 credits)</button>`;
+      }
+      box.innerHTML = badge + '<pre>' + escapeHtml(data.response) + '</pre>' + publishBtn;
+    }
+
+    async function publish() {
+      if (!lastAsk) return;
+      const r = await fetch('/api/publish', { method: 'POST',
+        headers: {'Content-Type':'application/json'},
+        body: JSON.stringify({
+          prompt: lastAsk.prompt, response: lastAsk.response,
+          embedding: lastAsk.embedding, tags: []
+        })});
+      if (!r.ok) return alert('publish failed: ' + await r.text());
+      const data = await r.json();
+      alert(`published! +${data.creditsEarned} credits`);
+      fetchMe();
+    }
+
+    const u = () => document.getElementById('username');
+    const p = () => document.getElementById('password');
+    const escapeHtml = s => s.replace(/[&<>]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;'}[c]));
+
+    fetchMe();
+  </script>
+</body>
+</html>
+"""

--- a/openclaw/pytest.ini
+++ b/openclaw/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+asyncio_mode = auto
+testpaths = tests

--- a/openclaw/requirements-test.txt
+++ b/openclaw/requirements-test.txt
@@ -1,0 +1,2 @@
+pytest==8.3.4
+pytest-asyncio==0.24.0

--- a/openclaw/requirements.txt
+++ b/openclaw/requirements.txt
@@ -1,8 +1,6 @@
 fastapi==0.115.0
-uvicorn[standard]==0.30.6
+uvicorn[standard]==0.32.0
 httpx==0.27.2
-aiosqlite==0.20.0
-python-multipart==0.0.12
-sse-starlette==2.1.3
 pydantic==2.9.2
-PyMuPDF==1.24.11
+pypdf==4.3.1
+python-multipart==0.0.9

--- a/openclaw/tests/test_ollama_client.py
+++ b/openclaw/tests/test_ollama_client.py
@@ -1,0 +1,257 @@
+"""
+Unit tests for app/ollama_client.py.
+
+Tests the Ollama HTTP wrapper in isolation — all network calls are mocked.
+Run:  pytest tests/ -v
+"""
+from __future__ import annotations
+
+import json
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app import ollama_client
+
+FAKE_EMBEDDING = [0.01] * 768
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _json_response(payload: dict) -> MagicMock:
+    """Mock httpx response that returns payload from .json()."""
+    mock = MagicMock()
+    mock.raise_for_status = MagicMock()
+    mock.json.return_value = payload
+    return mock
+
+
+def _async_client_ctx(mock_client: AsyncMock) -> AsyncMock:
+    """Wrap a mock client in an async context manager."""
+    mock_cm = AsyncMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_cm.__aexit__ = AsyncMock(return_value=False)
+    return mock_cm
+
+
+def _streaming_ctx(sse_lines: list[str]) -> AsyncMock:
+    """
+    Build a mock for:
+        async with client.stream(...) as r:
+            async for line in r.aiter_lines(): ...
+    """
+    async def fake_aiter_lines():
+        for line in sse_lines:
+            yield line
+        # also yield an empty line — the real stream often has these
+        yield ""
+
+    stream_resp = AsyncMock()
+    stream_resp.__aenter__ = AsyncMock(return_value=stream_resp)
+    stream_resp.__aexit__ = AsyncMock(return_value=False)
+    stream_resp.aiter_lines = fake_aiter_lines
+
+    mock_client = AsyncMock()
+    mock_client.stream = MagicMock(return_value=stream_resp)
+    return _async_client_ctx(mock_client)
+
+
+# ═════════════════════════════════════════════════════════════════════════════
+#  embed()
+# ═════════════════════════════════════════════════════════════════════════════
+
+@pytest.mark.asyncio
+async def test_embed_returns_list_of_floats():
+    """embed() should return the embedding vector from Ollama's response."""
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(return_value=_json_response({"embedding": FAKE_EMBEDDING}))
+
+    with patch("app.ollama_client.httpx.AsyncClient", return_value=_async_client_ctx(mock_client)):
+        result = await ollama_client.embed("hello world")
+
+    assert isinstance(result, list)
+    assert len(result) == 768
+    assert result == FAKE_EMBEDDING
+
+
+@pytest.mark.asyncio
+async def test_embed_posts_to_correct_endpoint():
+    """embed() must POST to /api/embeddings with model + prompt fields."""
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(return_value=_json_response({"embedding": FAKE_EMBEDDING}))
+
+    with patch("app.ollama_client.httpx.AsyncClient", return_value=_async_client_ctx(mock_client)):
+        await ollama_client.embed("test query")
+
+    call_kwargs = mock_client.post.call_args
+    posted_url = call_kwargs[0][0]
+    posted_json = call_kwargs[1]["json"]
+
+    assert "/api/embeddings" in posted_url
+    assert posted_json["prompt"] == "test query"
+    assert "model" in posted_json
+
+
+# ═════════════════════════════════════════════════════════════════════════════
+#  chat()
+# ═════════════════════════════════════════════════════════════════════════════
+
+@pytest.mark.asyncio
+async def test_chat_returns_message_content():
+    """chat() should return only the message content string."""
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(
+        return_value=_json_response({"message": {"content": "The capital is Paris."}})
+    )
+
+    with patch("app.ollama_client.httpx.AsyncClient", return_value=_async_client_ctx(mock_client)):
+        result = await ollama_client.chat("What is the capital of France?")
+
+    assert result == "The capital is Paris."
+
+
+@pytest.mark.asyncio
+async def test_chat_includes_system_message_when_provided():
+    """When a system prompt is given, it must appear first in the messages array."""
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(
+        return_value=_json_response({"message": {"content": "Sure!"}})
+    )
+
+    with patch("app.ollama_client.httpx.AsyncClient", return_value=_async_client_ctx(mock_client)):
+        await ollama_client.chat("Do X", system="You are a helpful assistant.")
+
+    posted_json = mock_client.post.call_args[1]["json"]
+    messages = posted_json["messages"]
+
+    assert messages[0]["role"] == "system"
+    assert messages[0]["content"] == "You are a helpful assistant."
+    assert messages[1]["role"] == "user"
+
+
+# ═════════════════════════════════════════════════════════════════════════════
+#  chat_stream_messages()
+# ═════════════════════════════════════════════════════════════════════════════
+
+@pytest.mark.asyncio
+async def test_stream_yields_token_chunks_in_order():
+    """chat_stream_messages() must yield each non-empty content chunk in order."""
+    sse_lines = [
+        json.dumps({"message": {"content": "Hello"}, "done": False}),
+        json.dumps({"message": {"content": " "}, "done": False}),
+        json.dumps({"message": {"content": "world"}, "done": False}),
+        json.dumps({"done": True, "eval_count": 3, "prompt_eval_count": 8,
+                    "eval_duration": 300_000_000}),
+    ]
+
+    with patch("app.ollama_client.httpx.AsyncClient", return_value=_streaming_ctx(sse_lines)):
+        chunks = []
+        async for chunk in ollama_client.chat_stream_messages(
+            [{"role": "user", "content": "Say hello"}]
+        ):
+            chunks.append(chunk)
+
+    assert chunks == ["Hello", " ", "world"]
+
+
+@pytest.mark.asyncio
+async def test_stream_skips_empty_content_chunks():
+    """Chunks with empty content strings must not be yielded."""
+    sse_lines = [
+        json.dumps({"message": {"content": "Hi"}, "done": False}),
+        json.dumps({"message": {"content": ""}, "done": False}),   # empty — skip
+        json.dumps({"message": {"content": "!"}, "done": False}),
+        json.dumps({"done": True, "eval_count": 2, "prompt_eval_count": 4,
+                    "eval_duration": 100_000_000}),
+    ]
+
+    with patch("app.ollama_client.httpx.AsyncClient", return_value=_streaming_ctx(sse_lines)):
+        chunks = []
+        async for chunk in ollama_client.chat_stream_messages(
+            [{"role": "user", "content": "hi"}]
+        ):
+            chunks.append(chunk)
+
+    assert "" not in chunks
+    assert chunks == ["Hi", "!"]
+
+
+@pytest.mark.asyncio
+async def test_stream_populates_out_meta_on_done():
+    """Token counts from the done event must be written into the out_meta dict."""
+    sse_lines = [
+        json.dumps({"message": {"content": "token"}, "done": False}),
+        json.dumps({
+            "done": True,
+            "eval_count": 7,
+            "prompt_eval_count": 12,
+            "eval_duration": 500_000_000,
+        }),
+    ]
+
+    out_meta: dict = {}
+    with patch("app.ollama_client.httpx.AsyncClient", return_value=_streaming_ctx(sse_lines)):
+        async for _ in ollama_client.chat_stream_messages(
+            [{"role": "user", "content": "hi"}], out_meta=out_meta
+        ):
+            pass
+
+    assert out_meta["eval_count"] == 7
+    assert out_meta["prompt_eval_count"] == 12
+    assert out_meta["eval_duration_ns"] == 500_000_000
+
+
+@pytest.mark.asyncio
+async def test_stream_out_meta_not_populated_when_none():
+    """Passing out_meta=None must not raise any errors."""
+    sse_lines = [
+        json.dumps({"message": {"content": "ok"}, "done": False}),
+        json.dumps({"done": True, "eval_count": 1, "prompt_eval_count": 2,
+                    "eval_duration": 50_000_000}),
+    ]
+
+    with patch("app.ollama_client.httpx.AsyncClient", return_value=_streaming_ctx(sse_lines)):
+        chunks = []
+        # out_meta defaults to None — should not raise
+        async for chunk in ollama_client.chat_stream_messages(
+            [{"role": "user", "content": "hi"}]
+        ):
+            chunks.append(chunk)
+
+    assert chunks == ["ok"]
+
+
+@pytest.mark.asyncio
+async def test_stream_options_include_temperature_and_num_ctx():
+    """temperature and num_ctx must be sent in the Ollama request options."""
+    sse_lines = [
+        json.dumps({"message": {"content": "x"}, "done": False}),
+        json.dumps({"done": True, "eval_count": 1, "prompt_eval_count": 1,
+                    "eval_duration": 10_000_000}),
+    ]
+
+    stream_resp = AsyncMock()
+    stream_resp.__aenter__ = AsyncMock(return_value=stream_resp)
+    stream_resp.__aexit__ = AsyncMock(return_value=False)
+
+    async def fake_lines():
+        for l in sse_lines:
+            yield l
+
+    stream_resp.aiter_lines = fake_lines
+
+    mock_client = AsyncMock()
+    mock_client.stream = MagicMock(return_value=stream_resp)
+    mock_cm = _async_client_ctx(mock_client)
+
+    with patch("app.ollama_client.httpx.AsyncClient", return_value=mock_cm):
+        async for _ in ollama_client.chat_stream_messages(
+            [{"role": "user", "content": "hi"}],
+            temperature=1.2,
+            num_ctx=4096,
+        ):
+            pass
+
+    call_kwargs = mock_client.stream.call_args[1]
+    options = call_kwargs["json"]["options"]
+    assert options["temperature"] == 1.2
+    assert options["num_ctx"] == 4096

--- a/openclaw/tests/test_server.py
+++ b/openclaw/tests/test_server.py
@@ -1,0 +1,301 @@
+"""
+Unit tests for app/server.py — FastAPI routes and marketplace decision logic.
+
+Run:  pytest tests/ -v
+"""
+from __future__ import annotations
+
+import io
+import json
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from fastapi.testclient import TestClient
+
+from app.server import app
+
+# ── Shared constants ──────────────────────────────────────────────────────────
+
+FAKE_EMBEDDING = [0.01] * 768  # nomic-embed-text is 768-dim
+
+# ── Shared async generator used to fake Ollama streaming ─────────────────────
+
+async def _fake_stream(messages, model=None, temperature=0.7,
+                       num_ctx=8192, out_meta=None):
+    """Yields two tokens then populates out_meta like the real function does."""
+    yield "Hello"
+    yield " world"
+    if out_meta is not None:
+        out_meta["eval_count"] = 2
+        out_meta["prompt_eval_count"] = 5
+        out_meta["eval_duration_ns"] = 200_000_000  # 0.2s → 10 tok/s
+
+
+def _sse_events(response_text: str) -> list[dict]:
+    """Parse raw SSE text into a list of JSON payload dicts."""
+    events = []
+    for line in response_text.splitlines():
+        if line.startswith("data: "):
+            try:
+                events.append(json.loads(line[6:]))
+            except json.JSONDecodeError:
+                pass
+    return events
+
+
+def _mock_ollama_tags(model_names: list[str]):
+    """Return a patch context that fakes Ollama GET /api/tags."""
+    fake_resp = MagicMock()
+    fake_resp.raise_for_status = MagicMock()
+    fake_resp.json.return_value = {"models": [{"name": n} for n in model_names]}
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=fake_resp)
+    mock_cm = AsyncMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_cm.__aexit__ = AsyncMock(return_value=False)
+    return patch("app.server.httpx.AsyncClient", return_value=mock_cm)
+
+
+# ═════════════════════════════════════════════════════════════════════════════
+#  GET /api/models
+# ═════════════════════════════════════════════════════════════════════════════
+
+class TestModelsEndpoint:
+    """Embedding models must be invisible to the user — only chat models shown."""
+
+    def test_embed_models_are_filtered_out(self):
+        """nomic-embed-text, mxbai-embed-large, and all-minilm must be excluded."""
+        ollama_models = [
+            "qwen2.5-coder:14b",
+            "llama3.2:3b",
+            "nomic-embed-text",   # should be excluded
+            "mxbai-embed-large",  # should be excluded
+            "all-minilm",         # should be excluded
+        ]
+        with _mock_ollama_tags(ollama_models):
+            with TestClient(app) as client:
+                r = client.get("/api/models")
+
+        assert r.status_code == 200
+        names = r.json()["models"]
+        assert "nomic-embed-text" not in names
+        assert "mxbai-embed-large" not in names
+        assert "all-minilm" not in names
+        assert "qwen2.5-coder:14b" in names
+        assert "llama3.2:3b" in names
+
+    def test_chat_models_are_preserved(self):
+        """Non-embed models must all be returned unchanged."""
+        chat_models = ["llava:13b", "phi4:latest", "gemma3:9b"]
+        with _mock_ollama_tags(chat_models):
+            with TestClient(app) as client:
+                r = client.get("/api/models")
+
+        assert r.status_code == 200
+        for m in chat_models:
+            assert m in r.json()["models"]
+
+    def test_all_embed_models_returns_empty_list(self):
+        """If every installed model is embed-only, return an empty list — not 500."""
+        with _mock_ollama_tags(["nomic-embed-text", "mxbai-embed-large"]):
+            with TestClient(app) as client:
+                r = client.get("/api/models")
+
+        assert r.status_code == 200
+        assert r.json()["models"] == []
+
+    def test_ollama_unreachable_returns_empty_not_500(self):
+        """A network error talking to Ollama must not propagate as a 500."""
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=OSError("connection refused"))
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_cm.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("app.server.httpx.AsyncClient", return_value=mock_cm):
+            with TestClient(app) as client:
+                r = client.get("/api/models")
+
+        assert r.status_code == 200
+        assert r.json() == {"models": []}
+
+
+# ═════════════════════════════════════════════════════════════════════════════
+#  POST /api/parse/pdf
+# ═════════════════════════════════════════════════════════════════════════════
+
+class TestPdfEndpoint:
+    """PDF upload → text extraction."""
+
+    @staticmethod
+    def _blank_pdf_bytes() -> bytes:
+        from pypdf import PdfWriter
+        writer = PdfWriter()
+        writer.add_blank_page(width=72, height=72)
+        buf = io.BytesIO()
+        writer.write(buf)
+        return buf.getvalue()
+
+    def test_valid_pdf_returns_200_with_page_count(self):
+        pdf = self._blank_pdf_bytes()
+        with TestClient(app) as client:
+            r = client.post(
+                "/api/parse/pdf",
+                files={"file": ("doc.pdf", io.BytesIO(pdf), "application/pdf")},
+            )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["pages"] == 1
+        assert "text" in data
+
+    def test_blank_pdf_has_empty_text(self):
+        """A blank page has no extractable text — must return empty string."""
+        pdf = self._blank_pdf_bytes()
+        with TestClient(app) as client:
+            r = client.post(
+                "/api/parse/pdf",
+                files={"file": ("blank.pdf", io.BytesIO(pdf), "application/pdf")},
+            )
+        assert r.status_code == 200
+        assert r.json()["text"] == ""
+
+
+# ═════════════════════════════════════════════════════════════════════════════
+#  POST /api/ask/stream  — marketplace routing logic
+# ═════════════════════════════════════════════════════════════════════════════
+
+class TestAskStream:
+    """Core marketplace decision: verbatim / repackage / miss."""
+
+    def test_miss_streams_tokens_and_done_event(self):
+        """No cache hit → Ollama is called, chunks are streamed, mode is 'miss'."""
+        with (
+            patch("app.server.ollama_client.embed", new=AsyncMock(return_value=FAKE_EMBEDDING)),
+            patch("app.server.market.token", new="fake-jwt"),
+            patch("app.server.market.search", new=AsyncMock(return_value=[])),
+            patch("app.server.ollama_client.chat_stream_messages", new=_fake_stream),
+        ):
+            with TestClient(app) as client:
+                r = client.post("/api/ask/stream", json={
+                    "prompt": "What is entropy?",
+                    "model": "qwen2.5-coder:14b",
+                })
+
+        assert r.status_code == 200
+        events = _sse_events(r.text)
+        chunks = [e["chunk"] for e in events if "chunk" in e]
+        done = [e for e in events if e.get("done")]
+
+        assert "".join(chunks) == "Hello world"
+        assert len(done) == 1
+        assert done[0]["mode"] == "miss"
+        assert "embedding" in done[0]
+
+    def test_verbatim_hit_skips_ollama_and_returns_cached_response(self):
+        """Similarity ≥ 0.90 → serve cached answer, never call chat_stream_messages."""
+        cache_entry = {
+            "mode": "verbatim",
+            "id": "uuid-abc",
+            "author": "alice",
+            "similarity": 0.97,
+            "response": "Entropy is disorder.",
+        }
+        stream_spy = MagicMock()  # should not be called
+
+        with (
+            patch("app.server.ollama_client.embed", new=AsyncMock(return_value=FAKE_EMBEDDING)),
+            patch("app.server.market.token", new="fake-jwt"),
+            patch("app.server.market.search", new=AsyncMock(return_value=[cache_entry])),
+            patch("app.server.market.consume", new=AsyncMock(return_value={})),
+            patch("app.server.ollama_client.chat_stream_messages", new=stream_spy),
+        ):
+            with TestClient(app) as client:
+                r = client.post("/api/ask/stream", json={"prompt": "What is entropy?"})
+
+        assert r.status_code == 200
+        events = _sse_events(r.text)
+        done = [e for e in events if e.get("done")]
+
+        assert done[0]["mode"] == "verbatim"
+        assert done[0]["source_author"] == "alice"
+        assert abs(done[0]["similarity"] - 0.97) < 0.001
+        stream_spy.assert_not_called()
+
+    def test_marketplace_bypassed_when_history_present(self):
+        """Multi-turn (history provided) must skip marketplace search entirely."""
+        search_spy = AsyncMock(return_value=[])
+
+        with (
+            patch("app.server.ollama_client.embed", new=AsyncMock(return_value=FAKE_EMBEDDING)),
+            patch("app.server.market.token", new="fake-jwt"),
+            patch("app.server.market.search", new=search_spy),
+            patch("app.server.ollama_client.chat_stream_messages", new=_fake_stream),
+        ):
+            with TestClient(app) as client:
+                r = client.post("/api/ask/stream", json={
+                    "prompt": "And what about temperature?",
+                    "model": "qwen2.5-coder:14b",
+                    "history": [
+                        {"role": "user",      "content": "What is entropy?"},
+                        {"role": "assistant", "content": "Entropy is disorder."},
+                    ],
+                })
+
+        assert r.status_code == 200
+        search_spy.assert_not_called()
+
+    def test_marketplace_bypassed_for_vision_request(self):
+        """Image attachments (image_b64 present) must skip marketplace search."""
+        search_spy = AsyncMock(return_value=[])
+
+        with (
+            patch("app.server.ollama_client.embed", new=AsyncMock(return_value=FAKE_EMBEDDING)),
+            patch("app.server.market.token", new="fake-jwt"),
+            patch("app.server.market.search", new=search_spy),
+            patch("app.server.ollama_client.chat_stream_messages", new=_fake_stream),
+        ):
+            with TestClient(app) as client:
+                r = client.post("/api/ask/stream", json={
+                    "prompt": "Describe this image.",
+                    "image_b64": "aGVsbG8=",  # base64("hello"), fake image
+                })
+
+        assert r.status_code == 200
+        search_spy.assert_not_called()
+
+    def test_done_event_includes_token_counts_on_miss(self):
+        """tokens_in, tokens_out, and toks_per_sec must appear on a miss done event."""
+        with (
+            patch("app.server.ollama_client.embed", new=AsyncMock(return_value=FAKE_EMBEDDING)),
+            patch("app.server.market.token", new="fake-jwt"),
+            patch("app.server.market.search", new=AsyncMock(return_value=[])),
+            patch("app.server.ollama_client.chat_stream_messages", new=_fake_stream),
+        ):
+            with TestClient(app) as client:
+                r = client.post("/api/ask/stream", json={"prompt": "hello"})
+
+        events = _sse_events(r.text)
+        done = [e for e in events if e.get("done")][0]
+
+        assert "tokens_in" in done
+        assert "tokens_out" in done
+        assert "toks_per_sec" in done
+        assert done["tokens_out"] == 2
+        assert done["tokens_in"] == 5
+        assert done["toks_per_sec"] == 10.0  # 2 tokens / 0.2s
+
+    def test_custom_temperature_is_accepted(self):
+        """temperature field in request body must not cause a 422 validation error."""
+        with (
+            patch("app.server.ollama_client.embed", new=AsyncMock(return_value=FAKE_EMBEDDING)),
+            patch("app.server.market.token", new="fake-jwt"),
+            patch("app.server.market.search", new=AsyncMock(return_value=[])),
+            patch("app.server.ollama_client.chat_stream_messages", new=_fake_stream),
+        ):
+            with TestClient(app) as client:
+                r = client.post("/api/ask/stream", json={
+                    "prompt": "Be creative",
+                    "temperature": 1.5,
+                })
+
+        assert r.status_code == 200


### PR DESCRIPTION
## Summary

This PR adds real time SSE streaming for all chat responses, per response token metrics, temperature and context window controls, image and PDF file attachments, and the full embed to search to verbatim/repackage/miss marketplace pipeline connected end to end between the frontend, OpenClaw local node, and the Spring Boot cloud backend.

## Type of change

- [x] New feature  
- [x] Refactor  

## Changes

### OpenClaw backend

**`ollama_client.py`** (new module extracted from scattered inline calls)

- `chat_stream_messages()` supports multi turn streaming with `temperature` and `num_ctx` options forwarded to Ollama. It also accepts an optional `out_meta={}` dictionary that gets populated with `eval_count`, `prompt_eval_count`, and `eval_duration_ns` from Ollama’s `done` event. This is how token metrics are captured without needing a second API call.
- `chat_vision_stream()` adds streaming vision chat support by sending a base64 image alongside the prompt using the `images` field.
- `EMBED_MODEL`, `DEFAULT_CHAT_MODEL`, and `OLLAMA_URL` are now sourced from environment variables with sensible defaults.

**`market_client.py`** (new module replacing scattered `httpx` calls)

- Async HTTP client wrapping the Spring Boot marketplace API with support for `register`, `login`, `me`, `search`, `publish`, `consume`, and `mine`.
- Stores the JWT token in memory and automatically attaches `Authorization: Bearer` headers on all requests.

**`server.py`** (major rewrite with old router structure removed)

- `POST /api/ask` adds the non streaming embed to search to verbatim/repackage/miss pipeline.
- `POST /api/ask/stream` adds the SSE streaming version of the same pipeline. Verbatim hits stream cached answers instantly, while repackage and miss responses stream tokens in real time. The `done` event includes `tokens_in`, `tokens_out`, `toks_per_sec`, `mode`, `source_author`, `similarity`, and `embedding`.
- `POST /api/parse/pdf` uses `pypdf` for text extraction and returns `{text}` so the frontend can prepend extracted PDF text to prompts.
- `GET /api/models` queries Ollama `/api/tags` and filters out embed only models like `nomic-embed-text` and `mxbai-embed-large` so the UI only displays chat capable models.
- `POST /api/publish` publishes miss responses including prompt, response, embedding, and tags to the marketplace through `MarketClient`.
- Added auth pass through endpoints for `POST /api/register`, `POST /api/login`, and `GET /api/me` that delegate to Spring Boot.

### Frontend

**`Chat.tsx`** (major rewrite)

- Replaced fetch and JSON handling with an SSE reader loop using `/api/ask/stream`, allowing assistant messages to stream in real time.
- Added multi turn history support. Messages from the current session are passed as `history` on all non first turns, while the first message is sent without history so marketplace lookup is still eligible.
- Added file attachment support:
  - Image files are converted to base64 with local `<img>` previews.
  - PDF files are uploaded to `/api/parse/pdf` and extracted text is prepended to the prompt.
  - Object URLs for image previews are revoked on unmount to avoid memory leaks.
- Added mode badges for assistant messages:
  - `✓ Cached answer` for verbatim
  - `↻ Repackaged` for repackage
  - `✗ Fresh inference` for miss
- Added source author and cosine similarity display for cache hits.
- Added a publish button for eligible miss responses where `mode === "miss"` and an embedding exists. This calls `POST /api/publish` and displays a toast showing credits earned.
- Added a token stats row showing tokens in, tokens out, and tokens per second.
- Added a context fill bar showing `(tokensIn + tokensOut) / contextWindowSize` with green, amber, and red progression plus warning banners near the limit.
- Added markdown rendering using `ReactMarkdown`, `remark-math`, `rehype-katex`, and `react-syntax-highlighter`.
- Added an auto resizing textarea with a maximum height of 200px.

**`models.ts`** (new utility)

- `modelColor()` generates deterministic colors based on model names.
- `contextWindowSize()` maps context windows for model families like qwen, llama, mistral, phi, and gemma.
- `ctxFillColor()` and `ctxWarning()` return fill colors and warning text based on context usage percentage.

**`App.tsx` / CSS**

- Added support for the updated session structure using `LocalSession` and `LocalMessage` with fields including `mode`, `tokensIn`, `tokensOut`, `toksPerSec`, `embedding`, and `published`.
- Added model selector, temperature slider, and credits display.

## Privacy / security

All inference runs locally through Ollama. Marketplace search sends only the embedding vector to the cloud backend, never the raw prompt text. Raw prompts only leave the local node when the user explicitly clicks “Publish.”

## Testing

- [x] Added unit tests in `openclaw/tests/test_server.py` covering register, login, ask flows (verbatim, repackage, miss), publish, model filtering, and PDF parsing.
- [x] Added unit tests in `openclaw/tests/test_ollama_client.py` covering `embed`, `chat`, `chat_stream`, `chat_stream_messages` including token metric capture, and `chat_vision_stream`.
- [x] Manually tested full workflow:
  - `python local_node.py start`
  - register
  - first turn ask (miss)
  - second turn multi turn bypass
  - publish
  - verbatim hit on re ask
  - image attachment
  - PDF attachment
  - local only toggle
- [x] `cd openclaw && python -m pytest --tb=short -q`
  - 21 tests passing.